### PR TITLE
Validate bundle schema

### DIFF
--- a/onto_tool/bundle_schema.json
+++ b/onto_tool/bundle_schema.json
@@ -1,0 +1,143 @@
+{
+  "type": "object",
+  "required": [
+    "bundle",
+    "actions"
+  ],
+  "properties": {
+    "bundle": {
+      "type": "string",
+      "minLength": 1
+    },
+    "variables": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "tools": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "type",
+          "arguments"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "Java"
+            ]
+          },
+          "jar": {
+            "type": "string"
+          },
+          "arguments": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minLength": 2
+          }
+        }
+      }
+    },
+    "actions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "action"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "mkdir",
+              "copy",
+              "move",
+              "transform",
+              "markdown",
+              "graph"
+            ]
+          },
+          "source": {
+            "type": "string",
+            "minLength": 1
+          },
+          "target": {
+            "type": "string",
+            "minLength": 1
+          },
+          "version": {
+            "type": "string",
+            "minLength": 1
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "tool": {
+            "type": "string",
+            "minLength": 1
+          },
+          "directory": {
+            "type": "string",
+            "minLength": 1
+          },
+          "rename": {
+            "type": "object",
+            "properties": {
+              "from": {
+                "type": "string",
+                "minLength": 1
+              },
+              "to": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "from",
+              "to"
+            ],
+            "additionalProperties": false
+          },
+          "replace": {
+            "type": "object",
+            "properties": {
+              "from": {
+                "type": "string",
+                "minLength": 1
+              },
+              "to": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "from",
+              "to"
+            ],
+            "additionalProperties": false
+          },
+          "includes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/onto_tool/bundle_schema.json
+++ b/onto_tool/bundle_schema.json
@@ -1,15 +1,17 @@
 {
   "definitions": {
+    "non_empty_string": {
+      "type": "string",
+      "minLength": 1
+    },
     "from_to": {
       "type": "object",
       "properties": {
         "from": {
-          "type": "string",
-          "minLength": 1
+          "$ref": "#/definitions/non_empty_string"
         },
         "to": {
-          "type": "string",
-          "minLength": 1
+          "$ref": "#/definitions/non_empty_string"
         }
       },
       "required": [
@@ -17,10 +19,6 @@
         "to"
       ],
       "additionalProperties": false
-    },
-    "non_empty_string": {
-      "type": "string",
-      "minLength": 1
     },
     "include_list": {
       "type": "array",
@@ -95,7 +93,28 @@
             },
             "minLength": 2
           }
-        }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "Java"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "jar": {
+                  "$ref": "#/definitions/non_empty_string"
+                }
+              },
+              "required": [
+                "jar"
+              ]
+            }
+          }
+        ]
       }
     },
     "actions": {

--- a/onto_tool/bundle_schema.json
+++ b/onto_tool/bundle_schema.json
@@ -1,4 +1,58 @@
 {
+  "definitions": {
+    "from_to": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "string",
+          "minLength": 1
+        },
+        "to": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "from",
+        "to"
+      ],
+      "additionalProperties": false
+    },
+    "non_empty_string": {
+      "type": "string",
+      "minLength": 1
+    },
+    "include_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/non_empty_string"
+      },
+      "minLength": 1
+    },
+    "bulk_file_operation": {
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/non_empty_string"
+        },
+        "target": {
+          "$ref": "#/definitions/non_empty_string"
+        },
+        "rename": {
+          "$ref": "#/definitions/from_to"
+        },
+        "replace": {
+          "$ref": "#/definitions/from_to"
+        },
+        "includes": {
+          "$ref": "#/definitions/include_list"
+        }
+      },
+      "required": [
+        "source",
+        "target"
+      ]
+    }
+  },
   "type": "object",
   "required": [
     "bundle",
@@ -26,17 +80,13 @@
         ],
         "properties": {
           "name": {
-            "type": "string",
-            "minLength": 1
+            "$ref": "#/definitions/non_empty_string"
           },
           "type": {
             "type": "string",
             "enum": [
               "Java"
             ]
-          },
-          "jar": {
-            "type": "string"
           },
           "arguments": {
             "type": "array",
@@ -55,7 +105,6 @@
         "required": [
           "action"
         ],
-        "additionalProperties": false,
         "properties": {
           "action": {
             "type": "string",
@@ -67,76 +116,133 @@
               "markdown",
               "graph"
             ]
-          },
-          "source": {
-            "type": "string",
-            "minLength": 1
-          },
-          "target": {
-            "type": "string",
-            "minLength": 1
-          },
-          "version": {
-            "type": "string",
-            "minLength": 1
-          },
-          "title": {
-            "type": "string",
-            "minLength": 1
-          },
-          "tool": {
-            "type": "string",
-            "minLength": 1
-          },
-          "directory": {
-            "type": "string",
-            "minLength": 1
-          },
-          "rename": {
-            "type": "object",
-            "properties": {
-              "from": {
-                "type": "string",
-                "minLength": 1
-              },
-              "to": {
-                "type": "string",
-                "minLength": 1
-              }
-            },
-            "required": [
-              "from",
-              "to"
-            ],
-            "additionalProperties": false
-          },
-          "replace": {
-            "type": "object",
-            "properties": {
-              "from": {
-                "type": "string",
-                "minLength": 1
-              },
-              "to": {
-                "type": "string",
-                "minLength": 1
-              }
-            },
-            "required": [
-              "from",
-              "to"
-            ],
-            "additionalProperties": false
-          },
-          "includes": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "minLength": 1
-            },
-            "minLength": 1
           }
-        }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "action": {
+                  "const": "graph"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "source": {
+                  "$ref": "#/definitions/non_empty_string"
+                },
+                "target": {
+                  "$ref": "#/definitions/non_empty_string"
+                },
+                "version": {
+                  "$ref": "#/definitions/non_empty_string"
+                },
+                "title": {
+                  "$ref": "#/definitions/non_empty_string"
+                }
+              },
+              "required": [
+                "title",
+                "version",
+                "source",
+                "target"
+              ]
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "action": {
+                  "const": "markdown"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "source": {
+                  "$ref": "#/definitions/non_empty_string"
+                },
+                "target": {
+                  "$ref": "#/definitions/non_empty_string"
+                }
+              },
+              "required": [
+                "source",
+                "target"
+              ]
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "action": {
+                  "const": "mkdir"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "directory": {
+                  "$ref": "#/definitions/non_empty_string"
+                }
+              },
+              "required": [
+                "directory"
+              ]
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "action": {
+                  "const": "copy"
+                }
+              }
+            },
+            "then": {
+              "$ref": "#/definitions/bulk_file_operation"
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "action": {
+                  "const": "move"
+                }
+              }
+            },
+            "then": {
+              "$ref": "#/definitions/bulk_file_operation"
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "action": {
+                  "const": "transform"
+                }
+              }
+            },
+            "then": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/bulk_file_operation"
+                },
+                {
+                  "properties": {
+                    "tool": {
+                      "$ref": "#/definitions/non_empty_string"
+                    }
+                  },
+                  "required": [
+                    "tool"
+                  ]
+                }
+              ]
+            }
+          }
+        ]
       }
     }
   }

--- a/onto_tool/onto_tool.py
+++ b/onto_tool/onto_tool.py
@@ -11,6 +11,7 @@ import subprocess
 import shutil
 import json
 import yaml
+from jsonschema import validate
 from rdflib import Graph, ConjunctiveGraph, URIRef, Literal
 from rdflib.namespace import RDF, RDFS, OWL, SKOS, XSD
 from rdflib.util import guess_format
@@ -476,12 +477,18 @@ def bundleOntology(command_line_variables, bundle_path):
 
     """
     extension = os.path.splitext(bundle_path)[1]
-    with open(bundle_path, 'r') as b_stream:
+    schema_file = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        'bundle_schema.json')
+    with open(bundle_path, 'r') as b_stream, open(schema_file, 'r') as schema:
         if extension == '.yaml':
             bundle = yaml.safe_load(b_stream)
         else:
             # assume json regardless of extension
             bundle = json.load(b_stream)
+
+        # will throw ValidationError on failure
+        validate(bundle, json.load(schema))
 
     variables = VarDict()
     variables.update(bundle['variables'])

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setuptools.setup(
         'jinja2',
         'markdown',
         'mdx_smartypants',
-        'pyyaml'
+        'pyyaml',
+        'jsonschema'
     ],
     classifiers=[
         "Development Status :: 4 - Beta",
@@ -27,6 +28,11 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
+    package_data={
+        'onto_tool': [
+            'bundle_schema.json'
+        ]
+    },
     entry_points={
         "console_scripts": [
             "onto_tool = onto_tool.onto_tool:run_tool"


### PR DESCRIPTION
Since there is no safety checking for arguments in the bundle methods, validate the definition up front using JSON Schema. Takes advantage of new Draft 7 conditional syntax to ensure each command has the appropriate parameters.