### PR TITLE
Add support for definedBy in bundle - closes #20

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,11 @@ one of the following values:
     supported as shown in the `rename` documentation.
 - `move`, which moves files according the provided options, which are identical to the ones supported
   by `copy`.
+- `definedBy`, which inspects each input file to identify a single defined ontology, and then
+  adds a `rdfs:isDefinedBy` property to every `owl:Class`, `owl:ObjectProperty`, `owl:DatatypeProperty`
+  and `owl:AnnotationProperty` defined in the file referencing the identified ontology. Existing
+  `rdfs:isDefinedBy` values are removed prior to the addition. Input and output file specification
+  options are identical to those used by the `copy` action.
 - `transform`, which applies the specified tool to a set of input files, and supports the following
   arguments:
   - `tool`, which references the `name` of a tool which must be defined in the `tools` section.

--- a/onto_tool/bundle_schema.json
+++ b/onto_tool/bundle_schema.json
@@ -133,7 +133,8 @@
               "move",
               "transform",
               "markdown",
-              "graph"
+              "graph",
+              "definedBy"
             ]
           }
         },
@@ -228,6 +229,18 @@
               "properties": {
                 "action": {
                   "const": "move"
+                }
+              }
+            },
+            "then": {
+              "$ref": "#/definitions/bulk_file_operation"
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "action": {
+                  "const": "definedBy"
                 }
               }
             },


### PR DESCRIPTION
You wanted this :) I will create a PR for the gist bundle changes if you are OK with this. The serialization `transform` action is replaced with 
```yaml
- action: "definedBy"
  source: "{input}/OntologyFiles"
  target: "{output}"
  rename:
    from: "(.*)\\.owl"
    to: "\\g<1>{version}.owl"
  includes:
    - "*.owl"
- action: "transform"
  tool: "serializer"
  replace:
    from: "X.x.x"
    to: "{version}"
  source: "{output}"
  target: "{output}"
  includes:
    - "*.owl"
```