### PR TITLE
Support output file argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,33 +32,9 @@ optional arguments:
 The `update` sub-command modifies ontology version and dependency information
 ```
 $ onto_tool update -h
-usage: onto_tool update [-h] [-b] [-v SET_VERSION]
-                        [-i [VERSION_INFO]] [-d DEPENDENCY VERSION]
-                        [ontology [ontology ...]]
-
-positional arguments:
-  ontology              Ontology file or directory containing OWL files.
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -b, --defined-by      Add rdfs:isDefinedBy to every resource defined.
-  -v SET_VERSION, --set-version SET_VERSION
-                        Set the version of the defined ontology
-  -i [VERSION_INFO], --version-info [VERSION_INFO]
-                        Adjust versionInfo, defaults to "Version X.x.x
-  -d DEPENDENCY VERSION, --dependency-version DEPENDENCY VERSION
-                        Update the import of DEPENDENCY to VERSION
-  -o {xml,turtle,nt}, --output-format {xml,turtle,nt}
-                        Output format
-```
-
-### Export
-
-The `export` sub-command will transform the ontology into the desired format, and remove version information, as required by tools such as Top Braid Composer.
-```
-$ onto_tool export -h
-usage: onto_tool export [-h] [-o {xml,turtle,nt} | -c CONTEXT] [-s]
-                        [-m IRI VERSION]
+usage: onto_tool update [-h] [-f {xml,turtle,nt} | -i] [-o OUTPUT] [-b]
+                        [-v SET_VERSION] [--version-info [VERSION_INFO]]
+                        [-d DEPENDENCY VERSION]
                         [ontology [ontology ...]]
 
 positional arguments:
@@ -66,10 +42,42 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -o {xml,turtle,nt}, --output-format {xml,turtle,nt}
+  -f {xml,turtle,nt}, --format {xml,turtle,nt}
+                        Output format
+  -i, --in-place        Overwrite each input file with update, preserving
+                        format
+  -o OUTPUT, --output OUTPUT
+                        Path to output file. Will be ignored if --in-place is
+                        specified.
+  -b, --defined-by      Add rdfs:isDefinedBy to every resource defined.
+  -v SET_VERSION, --set-version SET_VERSION
+                        Set the version of the defined ontology
+  --version-info [VERSION_INFO]
+                        Adjust versionInfo, defaults to "Version X.x.x
+  -d DEPENDENCY VERSION, --dependency-version DEPENDENCY VERSION
+                        Update the import of DEPENDENCY to VERSION
+```
+
+### Export
+
+The `export` sub-command will transform the ontology into the desired format, and remove version information, as required by tools such as Top Braid Composer.
+```
+$ onto_tool export -h
+usage: onto_tool export [-h] [-f {xml,turtle,nt} | -c CONTEXT] [-o OUTPUT]
+                        [-s] [-m IRI VERSION]
+                        [ontology [ontology ...]]
+
+positional arguments:
+  ontology              Ontology file or directory containing OWL files
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -f {xml,turtle,nt}, --format {xml,turtle,nt}
                         Output format
   -c CONTEXT, --context CONTEXT
                         Export as N-Quads in CONTEXT.
+  -o OUTPUT, --output OUTPUT
+                        Path to output file.
   -s, --strip-versions  Remove versions from imports.
   -m IRI VERSION, --merge IRI VERSION
                         Merge all inputs into a single ontology with the given

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ optional arguments:
   -v SET_VERSION, --set-version SET_VERSION
                         Set the version of the defined ontology
   --version-info [VERSION_INFO]
-                        Adjust versionInfo, defaults to "Version X.x.x
+                        Adjust versionInfo, defaults to "Version X.x.x"
   -d DEPENDENCY VERSION, --dependency-version DEPENDENCY VERSION
                         Update the import of DEPENDENCY to VERSION
 ```

--- a/onto_tool/onto_tool.py
+++ b/onto_tool/onto_tool.py
@@ -91,7 +91,7 @@ def configureArgParser():
                                help='Set the version of the defined ontology')
     update_parser.add_argument('--version-info', action="store",
                                nargs='?', const='auto',
-                               help='Adjust versionInfo, defaults to "Version X.x.x')
+                               help='Adjust versionInfo, defaults to "Version X.x.x"')
     update_parser.add_argument('-d', '--dependency-version', action="append",
                                metavar=('DEPENDENCY', 'VERSION'),
                                nargs=2, default=[],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="onto_tool",
-    version="0.5.0",
+    version="0.6.0",
     author="Boris Pelakh",
     author_email="boris.pelakh@semanticarts.com",
     description="Ontology Maintenance and Release Tool",
@@ -14,7 +14,7 @@ setuptools.setup(
     url="https://github.com/semanticarts/ontology-toolkit",
     packages=setuptools.find_packages(),
     install_requires=[
-        'rdflib',
+        'rdflib>=5.0.0',
         'pydot',
         'jinja2',
         'markdown',


### PR DESCRIPTION
* Add functionality to output `update` and `export` results into a specified file via `-o` flag.
* Rename `-o/--output-format` to `-f/--format` to be consistent across all sub-modules.
* Add `-i/--in-place` flag to `update` to apply the changes directly to the source files.

Bumped version to `0.6.0`, non-backward compatible arg changes, but hey, we are still in beta.
