### PR TITLE
Support generating isDefinedBy during merge/export.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The `export` sub-command will transform the ontology into the desired format, an
 ```
 $ onto_tool export -h
 usage: onto_tool export [-h] [-f {xml,turtle,nt} | -c CONTEXT] [-o OUTPUT]
-                        [-s] [-m IRI VERSION]
+                        [-s] [-m IRI VERSION] [-b [{all,strict}]]
                         [ontology [ontology ...]]
 
 positional arguments:
@@ -82,6 +82,13 @@ optional arguments:
   -m IRI VERSION, --merge IRI VERSION
                         Merge all inputs into a single ontology with the given
                         IRI and version
+  -b [{all,strict}], --defined-by [{all,strict}]
+                        Add rdfs:isDefinedBy to every resource defined. If the
+                        (default) "strict" argument is provided, only
+                        owl:Class, owl:ObjectProperty, owl:DatatypeProperty,
+                        owl:AnnotationProperty and owl:Thing entities will be
+                        annotated. If "all" is provided, every entity that has
+                        any properties other than rdf:type will be annotated.
 ```
 
 ### Graphic

--- a/onto_tool/onto_tool.py
+++ b/onto_tool/onto_tool.py
@@ -128,6 +128,9 @@ def configureArgParser():
                                'owl:AnnotationProperty and owl:Thing entities will be '
                                'annotated. If "all" is provided, every entity that has '
                                'any properties other than rdf:type will be annotated.')
+    export_parser.add_argument('--retain-definedBy', action="store_true",
+                               help='When merging ontologies, retain existing values '
+                               'of rdfs:isDefinedBy')
     export_parser.add_argument('ontology', nargs="*", default=[],
                                help="Ontology file or directory containing OWL files")
 
@@ -626,7 +629,7 @@ def exportOntology(args, output_format):
         if ontologyIRI is None:
             return
         addDefinedBy(parse_graph, ontologyIRI,
-                     mode=args.defined_by, replace=True)
+                     mode=args.defined_by, replace=not args.retain_definedBy)
 
     serialized = g.serialize(format=output_format)
     args.output.write(serialized.decode(args.output.encoding))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="onto_tool",
-    version="0.6.0",
+    version="0.7.0",
     author="Boris Pelakh",
     author_email="boris.pelakh@semanticarts.com",
     description="Ontology Maintenance and Release Tool",
@@ -14,7 +14,7 @@ setuptools.setup(
     url="https://github.com/semanticarts/ontology-toolkit",
     packages=setuptools.find_packages(),
     install_requires=[
-        'rdflib>=5.0.0',
+        'rdflib[sparql]>=5.0.0',
         'pydot',
         'jinja2',
         'markdown',


### PR DESCRIPTION
This is to support CBox versioning. For example I was able to group the entire Platts CBOX into a single named graph with an ontology object by running the following:
`onto_tool export --merge https://ontologies.platts.com/o/pleoTaxo 2.0.0 -c https://taxonomies.platts.com/pleo/taxonomy -b all -o pleoTaxo.nq  ../platts-ontology/taxonomy/*.ttl`