### PR TITLE
Unit tests, versioned definedBy. Fixes #35

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ optional arguments:
                         annotated. If "all" is provided, every entity that has
                         any properties other than rdf:type will be annotated.
                         Will override any existing rdfs:isDefinedBy
-                        annotations on the affected entities.
+                        annotations on the affected entities unless --retain-
+                        definedBy is specified.
   -v SET_VERSION, --set-version SET_VERSION
                         Set the version of the defined ontology
   --version-info [VERSION_INFO]

--- a/onto_tool/bundle_schema.json
+++ b/onto_tool/bundle_schema.json
@@ -262,7 +262,21 @@
               }
             },
             "then": {
-              "$ref": "#/definitions/bulk_file_operation"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/bulk_file_operation"
+                },
+                {
+                  "properties": {
+                    "retainDefinedBy": {
+                      "type": "boolean"
+                    },
+                    "versionedDefinedBy": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              ]
             }
           },
           {
@@ -294,6 +308,9 @@
                       ]
                     },
                     "retainDefinedBy": {
+                      "type": "boolean"
+                    },
+                    "versionedDefinedBy": {
                       "type": "boolean"
                     },
                     "stripVersions": {

--- a/onto_tool/onto_tool.py
+++ b/onto_tool/onto_tool.py
@@ -98,7 +98,8 @@ def configure_arg_parser():
                                'annotated. If "all" is provided, every entity that has '
                                'any properties other than rdf:type will be annotated. '
                                'Will override any existing rdfs:isDefinedBy annotations '
-                               'on the affected entities.')
+                               'on the affected entities unless --retain-definedBy is '
+                               'specified.')
     update_parser.add_argument('--retain-definedBy', action="store_true",
                                help='Retain existing values of rdfs:isDefinedBy')
     update_parser.add_argument('--versioned-definedBy', action="store_true",
@@ -460,7 +461,7 @@ def __perform_export__(output, output_format, paths, context=None,
         rdfs:isDefinedBy annotations with a reference to the new ontology.
         If True, however, existing rdfs:isDefinedBy values are left in place.
     versioned_defined_by : boolean, optional
-        The default (False) functionality is to use the ontology IRI fo
+        The default (False) functionality is to use the ontology IRI for
         rdfs:isDefinedBy annotations.
         If True and a versionIRI is present, use that instead.
 

--- a/onto_tool/onto_tool.py
+++ b/onto_tool/onto_tool.py
@@ -99,6 +99,10 @@ def configure_arg_parser():
                                'any properties other than rdf:type will be annotated. '
                                'Will override any existing rdfs:isDefinedBy annotations '
                                'on the affected entities.')
+    update_parser.add_argument('--retain-definedBy', action="store_true",
+                               help='Retain existing values of rdfs:isDefinedBy')
+    update_parser.add_argument('--versioned-definedBy', action="store_true",
+                               help='Use versionIRI for rdfs:isDefinedBy, when available')
     update_parser.add_argument('-v', '--set-version', action="store",
                                help='Set the version of the defined ontology')
     update_parser.add_argument('--version-info', action="store",
@@ -143,6 +147,8 @@ def configure_arg_parser():
     export_parser.add_argument('--retain-definedBy', action="store_true",
                                help='When merging ontologies, retain existing values '
                                'of rdfs:isDefinedBy')
+    export_parser.add_argument('--versioned-definedBy', action="store_true",
+                               help='Use versionIRI for rdfs:isDefinedBy, when available')
     export_parser.add_argument('ontology', nargs="*", default=[],
                                help="Ontology file or directory containing OWL files")
 
@@ -186,16 +192,16 @@ def findSingleOntology(g, onto_file):
     return ontology
 
 
-def setVersion(g, ontology, ontology_iri, version):
+def set_version(g, ontology, ontology_iri, version):
     """Add or replace versionIRI for the specified ontology."""
-    oldVersion = next(g.objects(ontology, OWL.versionIRI), None)
-    if oldVersion:
-        logging.debug(f'Removing versionIRI {oldVersion} from {ontology}')
-        g.remove((ontology, OWL.versionIRI, oldVersion))
+    old_version = next(g.objects(ontology, OWL.versionIRI), None)
+    if old_version:
+        logging.debug(f'Removing versionIRI {old_version} from {ontology}')
+        g.remove((ontology, OWL.versionIRI, old_version))
 
-    versionIRI = URIRef(f"{ontology_iri}{version}")
-    g.add((ontology, OWL.versionIRI, versionIRI))
-    logging.debug(f'versionIRI {versionIRI} added for {ontology}')
+    version_iri = URIRef(f"{ontology_iri}{version}")
+    g.add((ontology, OWL.versionIRI, version_iri))
+    logging.debug(f'versionIRI {version_iri} added for {ontology}')
 
 
 def set_version_info(g, ontology, version_info):
@@ -220,8 +226,12 @@ def set_version_info(g, ontology, version_info):
     logging.debug(f'versionInfo "{version_info}" added for {ontology}')
 
 
-def add_defined_by(g, ontology_iri, mode='strict', replace=False):
+def add_defined_by(g, ontology_iri, mode='strict', replace=False, versioned=False):
     """Add rdfs:isDefinedBy to every entity declared by the ontology."""
+    if versioned:
+        version_iri = next(g.objects(ontology_iri, OWL.versionIRI), None)
+        if version_iri is not None:
+            ontology_iri = version_iri
     if mode == 'strict':
         selector = """
           FILTER(?dtype IN (
@@ -416,7 +426,9 @@ def generateGraphic(fileRefs, compact, output, version):
 def __perform_export__(output, output_format, paths, context=None,
                        strip_versions=False,
                        merge=None,
-                       defined_by=None, retain_defined_by=False):
+                       defined_by=None,
+                       retain_defined_by=False,
+                       versioned_defined_by=False):
     """
     Export one or more files as a single output.
 
@@ -447,6 +459,10 @@ def __perform_export__(output, output_format, paths, context=None,
         The default (False) functionality is to replace any existing
         rdfs:isDefinedBy annotations with a reference to the new ontology.
         If True, however, existing rdfs:isDefinedBy values are left in place.
+    versioned_defined_by : boolean, optional
+        The default (False) functionality is to use the ontology IRI fo
+        rdfs:isDefinedBy annotations.
+        If True and a versionIRI is present, use that instead.
 
     Returns
     -------
@@ -477,7 +493,9 @@ def __perform_export__(output, output_format, paths, context=None,
         if ontology_iri is None:
             return
         add_defined_by(parse_graph, ontology_iri,
-                       mode=defined_by, replace=not retain_defined_by)
+                       mode=defined_by,
+                       replace=not retain_defined_by,
+                       versioned=versioned_defined_by)
 
     serialized = g.serialize(format=output_format)
     output.write(serialized.decode(output.encoding))
@@ -587,7 +605,9 @@ def __bundle_defined_by__(action, variables):
             # copy as unchanged
             shutil.copy(in_out['inputFile'], in_out['outputFile'])
         else:
-            add_defined_by(g, ontology)
+            add_defined_by(g, ontology,
+                           replace=not __boolean_option__(action, 'retainDefinedBy', variables),
+                           versioned=__boolean_option__(action, 'versionedDefinedBy', variables))
 
             g.serialize(destination=in_out['outputFile'],
                         format=rdf_format, encoding='utf-8')
@@ -685,7 +705,8 @@ def __bundle_export__(action, variables):
                        __boolean_option__(action, 'stripVersions', variables),
                        merge,
                        defined_by,
-                       __boolean_option__(action, 'retainDefinedBy', variables))
+                       __boolean_option__(action, 'retainDefinedBy', variables),
+                       __boolean_option__(action, 'versionedDefinedBy', variables))
 
     output.close()
 
@@ -762,7 +783,8 @@ def exportOntology(args, output_format):
                        'strip_versions' in args and args.strip_versions,
                        args.merge if 'merge' in args and args.merge else None,
                        defined_by,
-                       args.retain_definedBy)
+                       args.retain_definedBy,
+                       args.versioned_definedBy)
 
 
 def updateOntology(args, output_format):
@@ -783,7 +805,7 @@ def updateOntology(args, output_format):
 
         # Set version
         if 'set_version' in args and args.set_version:
-            setVersion(g, ontology, ontology_iri, args.set_version)
+            set_version(g, ontology, ontology_iri, args.set_version)
         if 'version_info' in args and args.version_info:
             version_info = args.version_info
             if version_info == 'auto':
@@ -797,7 +819,9 @@ def updateOntology(args, output_format):
 
         # Add rdfs:isDefinedBy
         if 'defined_by' in args and args.defined_by:
-            add_defined_by(g, ontology_iri, mode=args.defined_by, replace=True)
+            add_defined_by(g, ontology_iri, mode=args.defined_by,
+                           replace=not args.retain_definedBy,
+                           versioned=args.versioned_definedBy)
 
         # Update dep versions
         if 'dependency_version' in args and args.dependency_version:

--- a/tests/merge-subdomain.ttl
+++ b/tests/merge-subdomain.ttl
@@ -1,0 +1,10 @@
+@prefix : <https://data.clientX.com/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+:myProperty a owl:DatatypeProperty ;
+    skos:prefLabel "my property" .
+
+<https://data.clientX.com/d/subdomainOntology>
+    a owl:Ontology ;
+    owl:imports <https://data.clientX.com/d/topOntology1.2.0> .

--- a/tests/merge-top.ttl
+++ b/tests/merge-top.ttl
@@ -1,0 +1,7 @@
+@prefix : <https://data.clientX.com/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://data.clientX.com/d/topOntology>
+    a owl:Ontology ;
+    owl:imports <https://come.external.com/ontology1.3.0> .

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -56,3 +56,21 @@ def test_export_merge(capsys):
         [(URIRef('https://data.clientX.com/myProperty'),
           URIRef('https://data.clientX.com/d/coreOntology'))]
     )
+
+
+def test_versioned_defined_by(capsys):
+    onto_tool.main([
+        'export',
+        '-m', 'https://data.clientX.com/d/coreOntology', '2.0.0',
+        '-b', 'strict',
+        '--versioned-definedBy',
+        'tests/merge-subdomain.ttl', 'tests/merge-top.ttl'
+    ])
+    updated = capsys.readouterr().out
+    graph = Graph()
+    graph.parse(data=updated, format="turtle")
+    assert lists_equal(
+        list(graph.subject_objects(RDFS.isDefinedBy)),
+        [(URIRef('https://data.clientX.com/myProperty'),
+          URIRef('https://data.clientX.com/d/coreOntology2.0.0'))]
+    )

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,58 @@
+from rdflib import Graph, URIRef, Literal
+from rdflib.namespace import OWL, XSD, RDF, RDFS
+from onto_tool import onto_tool
+
+
+def lists_equal(list_one, list_two):
+    return len(list_one) == len(list_two) and sorted(list_one) == sorted(list_two)
+
+
+def test_export_strip_versions(capsys):
+    onto_tool.main([
+        'export', '-s',
+        'tests/update-tests.ttl'
+    ])
+    updated = capsys.readouterr().out
+    graph = Graph()
+    graph.parse(data=updated, format="turtle")
+    assert lists_equal(
+        list(graph.subject_objects(OWL.imports)),
+        [(URIRef('https://data.clientX.com/d/ontoName'),
+          URIRef('https://data.clientX.com/d/coreOntology'))]
+    )
+
+
+def test_export_merge(capsys):
+    onto_tool.main([
+        'export',
+        '-m', 'https://data.clientX.com/d/coreOntology', '2.0.0',
+        '-b', 'strict',
+        'tests/merge-subdomain.ttl', 'tests/merge-top.ttl'
+    ])
+    updated = capsys.readouterr().out
+    graph = Graph()
+    graph.parse(data=updated, format="turtle")
+    assert lists_equal(
+        list(graph.subjects(RDF.type, OWL.Ontology)),
+        [URIRef('https://data.clientX.com/d/coreOntology')]
+    )
+    assert lists_equal(
+        list(graph.subject_objects(OWL.imports)),
+        [(URIRef('https://data.clientX.com/d/coreOntology'),
+          URIRef('https://come.external.com/ontology1.3.0'))]
+    )
+    assert lists_equal(
+        list(graph.subject_objects(OWL.versionIRI)),
+        [(URIRef('https://data.clientX.com/d/coreOntology'),
+          URIRef('https://data.clientX.com/d/coreOntology2.0.0'))]
+    )
+    assert lists_equal(
+        list(graph.subject_objects(OWL.versionInfo)),
+        [(URIRef('https://data.clientX.com/d/coreOntology'),
+          Literal('Created by merge tool.', datatype=XSD.string))]
+    )
+    assert lists_equal(
+        list(graph.subject_objects(RDFS.isDefinedBy)),
+        [(URIRef('https://data.clientX.com/myProperty'),
+          URIRef('https://data.clientX.com/d/coreOntology'))]
+    )

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,47 @@
+from rdflib import Graph, URIRef, Literal
+from rdflib.namespace import OWL, XSD
+from onto_tool import onto_tool
+
+
+def lists_equal(list_one, list_two):
+    return len(list_one) == len(list_two) and sorted(list_one) == sorted(list_two)
+
+
+def test_update_version(capsys):
+    onto_tool.main([
+        'update',
+        '-v', '2.0.0',
+        '--version-info', "Release 2.0.0",
+        'tests/update-tests.ttl'
+    ])
+    updated = capsys.readouterr().out
+    graph = Graph()
+    graph.parse(data=updated, format="turtle")
+    assert lists_equal(
+        list(graph.subject_objects(OWL.versionIRI)),
+        [(URIRef('https://data.clientX.com/d/ontoName'),
+          URIRef('https://data.clientX.com/d/ontoName2.0.0'))]
+    )
+    assert lists_equal(
+        list(graph.subject_objects(OWL.versionInfo)),
+        [(URIRef('https://data.clientX.com/d/ontoName'),
+          Literal('Release 2.0.0', datatype=XSD.string))]
+    )
+
+
+def test_update_dependency(capsys):
+    onto_tool.main([
+        'update',
+        '-d', 'https://data.clientX.com/d/coreOntology', '2.0.0',
+        'tests/update-tests.ttl'
+    ])
+    updated = capsys.readouterr().out
+    graph = Graph()
+    graph.parse(data=updated, format="turtle")
+    assert lists_equal(
+        list(graph.subject_objects(OWL.imports)),
+        [(URIRef('https://data.clientX.com/d/ontoName'),
+          URIRef('https://data.clientX.com/d/coreOntology2.0.0'))]
+    )
+
+

--- a/tests/update-tests.ttl
+++ b/tests/update-tests.ttl
@@ -1,0 +1,15 @@
+@prefix : <https://data.clientX.com/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+:MyIndividual a :Resource ;
+    skos:prefLabel "Tom" .
+
+:myProperty a owl:DatatypeProperty ;
+    skos:prefLabel "my property" .
+
+<https://data.clientX.com/d/ontoName>
+    a owl:Ontology ;
+    owl:imports <https://data.clientX.com/d/coreOntology1.2.0> ;
+    owl:versionIRI <https://data.clientX.com/d/ontoNameX.x.x> ;
+    owl:versionInfo "Replace during build" .


### PR DESCRIPTION
* Removed `ontologyIRI`, since it was invalid.
* Add `--versioned-definedBy` option to `update`, and `export` modules, as well as `definedBy` and `export` actions in `bundle`.
* Started on unit tests for steel-thread functionality.

Code coverage is obviously not great yet, none of the bundle functionality is tested.
```
tests\test_export.py ...                                                 [ 37%]
tests\test_issue-36.py ...                                               [ 75%]
tests\test_update.py ..                                                  [100%]

----------- coverage: platform win32, python 3.7.4-final-0 -----------
Name                     Stmts   Miss  Cover
--------------------------------------------
onto_tool\__init__.py        0      0   100%
onto_tool\mdutils.py        21     13    38%
onto_tool\onto_tool.py     426    199    53%
onto_tool\ontograph.py      68     55    19%
--------------------------------------------
TOTAL                      515    267    48%


============================== 8 passed in 2.99s ==============================
```