### PR TITLE
Support sparql action in bundle. Fixes #44

### DIFF
--- a/onto_tool/bundle_schema.json
+++ b/onto_tool/bundle_schema.json
@@ -151,11 +151,50 @@
               "markdown",
               "graph",
               "definedBy",
-              "export"
+              "export",
+              "sparql"
             ]
           }
         },
         "allOf": [
+          {
+            "if": {
+              "properties": {
+                "action": {
+                  "const": "sparql"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "source": {
+                  "$ref": "#/definitions/non_empty_string"
+                },
+                "target": {
+                  "$ref": "#/definitions/non_empty_string"
+                },
+                "includes": {
+                  "$ref": "#/definitions/include_list"
+                },
+                "query": {
+                  "type": "string"
+                },
+                "format": {
+                  "type": "string",
+                  "enum": [
+                    "turtle",
+                    "xml",
+                    "nt"
+                  ]
+                }
+              },
+              "required": [
+                "query",
+                "source",
+                "target"
+              ]
+            }
+          },
           {
             "if": {
               "properties": {

--- a/tests/bundle/sparql.yaml
+++ b/tests/bundle/sparql.yaml
@@ -1,0 +1,25 @@
+bundle: test
+variables:
+  input: "tests"
+  output: "tests/bundle"
+actions:
+  - action: 'sparql'
+    source: '{input}'
+    includes:
+      - 'merge-top.ttl'
+    target: '{output}/sparql.ttl'
+    query: >
+      construct {{
+        ?s ?p ?o .
+      }}
+      WHERE {{
+        ?s ?p ?o .
+      }}
+  - action: 'sparql'
+    source: '{output}/sparql.ttl'
+    target: '{output}/sparql.csv'
+    query: >
+      select ?s ?p ?o
+      WHERE {{
+        ?s ?p ?o .
+      }} order by ?p

--- a/tests/bundle/test_sparql.py
+++ b/tests/bundle/test_sparql.py
@@ -1,0 +1,23 @@
+from onto_tool import onto_tool
+import csv
+
+
+def lists_equal(list_one, list_two):
+    return len(list_one) == len(list_two) and sorted(list_one) == sorted(list_two)
+
+
+def test_sparql_queries():
+    onto_tool.main([
+        'bundle', 'tests/bundle/sparql.yaml'
+    ])
+    with open('tests/bundle/sparql.csv') as csvfile:
+        actual = list(row for row in csv.DictReader(csvfile))
+    expected = [
+        {'s': 'https://data.clientX.com/d/topOntology',
+         'p': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+         'o': 'http://www.w3.org/2002/07/owl#Ontology'},
+        {'s': 'https://data.clientX.com/d/topOntology',
+         'p': 'http://www.w3.org/2002/07/owl#imports',
+         'o': 'https://come.external.com/ontology1.3.0'}
+    ]
+    assert actual == expected


### PR DESCRIPTION
Should be able to use this to create the `rdfs:label` extra file on the fly while packaging gist. Added the SELECT query capability in case we wanted to also gather some summary statistics during build (number of classes and properties, etc).

Continuing improvement in test coverage:
```
Name                     Stmts   Miss  Cover
--------------------------------------------
onto_tool\__init__.py        0      0   100%
onto_tool\mdutils.py        21     13    38%
onto_tool\onto_tool.py     453    168    63%
onto_tool\ontograph.py      68     55    19%
--------------------------------------------
TOTAL                      542    236    56%
```