### PR TITLE
Data graph, fixes #55

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,19 @@ optional arguments:
 
 ### Graphic
 
-The `graphic` sub-command will create either a comprehensive diagram showing ontology modules together with classes, object properties and "Things" together with the path of imports, or (if the 'wee' option is selected) a simple diagram of ontology modules and the import hierarchy.  Graphics are exported both as ```png``` files and also as a ```dot``` file.  This ```dot``` file can be used with Graphviz or with web tools such as [Model Viewer](http://www.semantechs.co.uk/model-viewer)
+The `graphic` sub-command will create either 
+* a comprehensive diagram showing ontology modules together with classes, object properties and "Things"
+  together with the path of imports, or (if the 'wee' option is selected) a simple diagram of ontology modules and
+  the import hierarchy, or
+* a diagram of the use of classes and object and data properties in a triple store.
+    
+Graphics are exported both as ```png``` files and also as a ```dot``` file.  This ```dot``` file can be used with Graphviz or with web tools such as [Model Viewer](http://www.semantechs.co.uk/model-viewer)
 
 ```
-$ onto_tool graphic -h
-usage: onto_tool graphic [-h] [--debug] [-o OUTPUT] [-v VERSION] [-w]
+usage: onto_tool graphic [-h] [-e ENDPOINT] [--schema | --data] [--debug]
+                         [-o OUTPUT] [--instance-limit INSTANCE_LIMIT]
+                         [--predicate-threshold PREDICATE_THRESHOLD]
+                         [-v VERSION] [-w]
                          [ontology [ontology ...]]
 
 positional arguments:
@@ -120,9 +128,18 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  -e ENDPOINT, --endpoint ENDPOINT
+                        URI of SPARQL endpoint to use to gather data
+  --schema              Generate ontology import graph (default)
+  --data                Analyze instances for types and links
   --debug               Emit verbose debug output
   -o OUTPUT, --output OUTPUT
                         Output directory for generated graphics
+  --instance-limit INSTANCE_LIMIT
+                        Size limit on instance queries (default 500000)
+  --predicate-threshold PREDICATE_THRESHOLD
+                        Ignore predicates which occur less than
+                        PREDICATE_THRESHOLD times (default 10)
   -v VERSION, --version VERSION
                         Version to place in graphic
   -w, --wee             a version of the graphic with only core information

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ optional arguments:
 ### Graphic
 
 The `graphic` sub-command will create either 
-* a comprehensive diagram showing ontology modules together with classes, object properties and "Things"
+* a comprehensive diagram showing ontology modules together with classes, object properties and individuals
   together with the path of imports, or (if the 'wee' option is selected) a simple diagram of ontology modules and
   the import hierarchy, or
 * a diagram of the use of classes and object and data properties in a triple store.

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ optional arguments:
 
 The `graphic` sub-command will create either 
 * a comprehensive diagram showing ontology modules together with classes, object properties and individuals
-  together with the path of imports, or (if the 'wee' option is selected) a simple diagram of ontology modules and
-  the import hierarchy, or
+  together with the path of imports, or (if the 'wee' option is selected) a simple diagram of the ontology
+  import hierarchy, or
 * a diagram of the use of classes and object and data properties in a triple store.
     
 Graphics are exported both as ```png``` files and also as a ```dot``` file.  This ```dot``` file can be used with Graphviz or with web tools such as [Dot Viewer](http://www.semantechs.co.uk/turtle-editor-viewer/)

--- a/onto_tool/ontograph.py
+++ b/onto_tool/ontograph.py
@@ -166,6 +166,10 @@ class OntoGraf():
         for entity in self.select_query(onto_query):
             onto_data[entity['ontology']][mapping[entity['type']]].append(self.strip_uri(entity['entity']))
 
+        if not onto_data:
+            logging.warning('Could not find any ontology entities in %s', self.repo)
+            return
+
         self.node_data = defaultdict(dict)
         for ontology, props in onto_data.items():
             self.node_data[ontology]['ontologyName'] = self.strip_uri(ontology)
@@ -288,6 +292,10 @@ class OntoGraf():
         """
         self.node_data = {}
         all_predicates = list(self.select_query(predicate_query))
+        if not all_predicates:
+            logging.warning('No interesting predicates found in %s', self.repo)
+            return
+
         for count, pred_row in enumerate(all_predicates):
             predicate_str = pred_row['label'] if pred_row.get('label') \
                 else self.strip_uri(pred_row['predicate'])

--- a/onto_tool/ontograph.py
+++ b/onto_tool/ontograph.py
@@ -304,6 +304,7 @@ class OntoGraf():
                 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
                 prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
                 prefix gist: <https://ontologies.semanticarts.com/gist/>
+                prefix skos: <http://www.w3.org/2004/02/skos/core#>
 
                 select ?src ?srcLabel
                        ?tgt ?tgtLabel
@@ -333,6 +334,7 @@ class OntoGraf():
                 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
                 prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
                 prefix gist: <https://ontologies.semanticarts.com/gist/>
+                prefix skos: <http://www.w3.org/2004/02/skos/core#>
 
                 select ?src ?srcLabel
                        ?dt
@@ -361,6 +363,7 @@ class OntoGraf():
                 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
                 prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
                 prefix gist: <https://ontologies.semanticarts.com/gist/>
+                prefix skos: <http://www.w3.org/2004/02/skos/core#>
 
                 select ?src ?srcLabel
                        ?tgt ?tgtLabel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rdflib[sparql]>=5.0.0
-pyshacl
+pyshacl~=0.14.0
 pydot>=1.4.1
 jinja2>=2.11.2
 markdown>=3.2.1
@@ -17,3 +17,5 @@ pyrsistent>=0.16.0
 setuptools>=40.8.0
 namedentities>=1.5.2
 zipp>=3.1.0
+pytest~=6.1.2
+SPARQLWrapper~=1.8.5

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="onto_tool",
-    version="1.0.1",
+    version="1.1.0",
     author="Boris Pelakh",
     author_email="boris.pelakh@semanticarts.com",
     description="Ontology Maintenance and Release Tool",
@@ -21,7 +21,8 @@ setuptools.setup(
         'markdown',
         'mdx_smartypants',
         'pyyaml',
-        'jsonschema>=3.2.0'
+        'jsonschema>=3.2.0',
+        'SPARQLWrapper>=1.8.5'
     ],
     tests_require=[
         'pytest'


### PR DESCRIPTION
Add the ability to generate a data graph from a triple store that displays usage of classes and properties, as displayed in the attached image.

![image](https://user-images.githubusercontent.com/44446537/111183515-5a2de080-8586-11eb-9e6c-ea8120dab276.png)

 Also add the ability to generate the ontology import graph from a repository in addition to local files.