### PR TITLE
Endpoint SPARQL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,15 @@ emitted as a `INFO`-level log message prior to the execution of the action.
     * `SELECT` query results are stored in the file specified via `target` as a CSV.
     * RDF results from a `CONSTRUCT` query are
   stored as either Turtle, RDF/XML or N-Triples, depending on the `format` option (`turtle`, `xml`, or `nt`).
+      Update queries will alter the input data in place, and the resulting
+      graph will be output in the specified format.
+    * As an alternative to operating on local RDF specified via 'source', a query can
+      be executed on a triple store by specifying an `endpoint`, which must
+      contain a `query_uri`, and can optionally specify `user`/`password` which will
+      authenticate via HTTP basic authentication. Update queries will modify the
+      triple store directly, and a separate `update_uri` can be specified
+      for databases which require it.
+
   
 ##### Utility Actions
 - `markdown` transforms a `.md` file referenced in `source` into an HTML output specified in `target`.
@@ -451,3 +460,18 @@ value of the `type` option:
   The validation will be considered as a failure if the resulting graph is non-empty. `target`,
   `stopOnFail` and `query`/`queries` are handled same as `select` validation, and `failOn` is used to determine which
   violations will terminate execution.
+* Validation can be performed against a SPARQL endpoint instead of local RDF
+  data by specifying `endpoint` instead of `source`/`includes`. `endpoint` must
+  contain a `query_uri`, and can optionally specify `user`/`password` which will
+  authenticate via HTTP basic authentication. For example:
+  ```
+  - action: 'verify'
+    type: 'construct'
+    endpoint:
+      query_uri: 'https://my.endpoint.com/sparql'
+      user: 'test-user'
+      password: 'test-user'
+    target: '{output}/verify_construct_results'
+    stopOnFail: false
+    query: '{input}/verify_via_construct.rq'
+  ```

--- a/onto_tool/bundle_schema.yaml
+++ b/onto_tool/bundle_schema.yaml
@@ -63,6 +63,20 @@ definitions:
               - source
         required:
           - queries
+  endpoint_spec:
+    type: object
+    properties:
+      query_uri:
+        $ref: '#/definitions/non_empty_string'
+      update_uri:
+        $ref: '#/definitions/non_empty_string'
+      user:
+        $ref: '#/definitions/non_empty_string'
+      password:
+        $ref: '#/definitions/non_empty_string'
+    required:
+      - query_uri
+    additionalProperties: false
 type: object
 required:
   - bundle
@@ -256,25 +270,38 @@ properties:
               action:
                 const: sparql
           then:
-            properties:
-              source:
-                $ref: '#/definitions/non_empty_string'
-              target:
-                $ref: '#/definitions/non_empty_string'
-              includes:
-                $ref: '#/definitions/include_list'
-              query:
-                $ref: '#/definitions/non_empty_string'
-              format:
-                type: string
-                enum:
-                  - turtle
-                  - xml
-                  - nt
-            required:
-              - query
-              - source
-              - target
+            oneOf:
+              - allOf:
+                - $ref: '#/definitions/multi_query_spec'
+                - properties:
+                    source:
+                      $ref: '#/definitions/non_empty_string'
+                    target:
+                      $ref: '#/definitions/non_empty_string'
+                    includes:
+                      $ref: '#/definitions/include_list'
+                    format:
+                      type: string
+                      enum:
+                        - turtle
+                        - xml
+                        - nt
+                  required:
+                    - source
+                    - target
+              - allOf:
+                - $ref: '#/definitions/multi_query_spec'
+                - properties:
+                    endpoint:
+                      $ref: '#/definitions/endpoint_spec'
+                    format:
+                      type: string
+                      enum:
+                        - turtle
+                        - xml
+                        - nt
+                  required:
+                    - endpoint
         - if:
             properties:
               action:

--- a/onto_tool/bundle_schema.yaml
+++ b/onto_tool/bundle_schema.yaml
@@ -341,6 +341,8 @@ properties:
                 - properties:
                     endpoint:
                       $ref: '#/definitions/endpoint_spec'
+                    target:
+                      $ref: '#/definitions/non_empty_string'
                     format:
                       type: string
                       enum:

--- a/onto_tool/bundle_schema.yaml
+++ b/onto_tool/bundle_schema.yaml
@@ -178,10 +178,6 @@ properties:
                 const: verify
           then:
             properties:
-              source:
-                $ref: '#/definitions/non_empty_string'
-              includes:
-                $ref: '#/definitions/include_list'
               type:
                 type: string
                 enum:
@@ -198,12 +194,17 @@ properties:
                   allOf:
                     - $ref: '#/definitions/multi_query_spec'
                     - properties:
+                        source:
+                          $ref: '#/definitions/non_empty_string'
+                        includes:
+                          $ref: '#/definitions/include_list'
                         stopOnFail:
                           type: boolean
                         expected:
                           type: boolean
                       required:
                         - expected
+                        - source
               - if:
                   properties:
                     type:
@@ -214,31 +215,77 @@ properties:
                     - properties:
                         stopOnFail:
                           type: boolean
+                        source:
+                          $ref: '#/definitions/non_empty_string'
+                        includes:
+                          $ref: '#/definitions/include_list'
                         target:
                           $ref: '#/definitions/non_empty_string'
+                      required:
+                        - source
               - if:
                   properties:
                     type:
                       const: construct
                 then:
-                  allOf:
-                    - $ref: '#/definitions/multi_query_spec'
-                    - properties:
-                        stopOnFail:
-                          type: boolean
-                        failOn:
-                          type: string
-                          enum:
-                            - "warning"
-                            - "violation"
-                        target:
-                          $ref: '#/definitions/non_empty_string'
+                  oneOf:
+                    - allOf:
+                      - $ref: '#/definitions/multi_query_spec'
+                      - properties:
+                          source:
+                            $ref: '#/definitions/non_empty_string'
+                          target:
+                            $ref: '#/definitions/non_empty_string'
+                          includes:
+                            $ref: '#/definitions/include_list'
+                          format:
+                            type: string
+                            enum:
+                              - turtle
+                              - xml
+                              - nt
+                          stopOnFail:
+                            type: boolean
+                          failOn:
+                            type: string
+                            enum:
+                              - "warning"
+                              - "violation"
+                        required:
+                          - source
+                          - target
+                    - allOf:
+                      - $ref: '#/definitions/multi_query_spec'
+                      - properties:
+                          endpoint:
+                            $ref: '#/definitions/endpoint_spec'
+                          format:
+                            type: string
+                            enum:
+                              - turtle
+                              - xml
+                              - nt
+                          stopOnFail:
+                            type: boolean
+                          failOn:
+                            type: string
+                            enum:
+                              - "warning"
+                              - "violation"
+                          target:
+                            $ref: '#/definitions/non_empty_string'
+                        required:
+                          - endpoint
               - if:
                   properties:
                     type:
                       const: shacl
                 then:
                   properties:
+                    source:
+                      $ref: '#/definitions/non_empty_string'
+                    includes:
+                      $ref: '#/definitions/include_list'
                     target:
                       $ref: '#/definitions/non_empty_string'
                     inference:
@@ -261,10 +308,10 @@ properties:
                         includes:
                           $ref: '#/definitions/include_list'
                   required:
+                    - source
                     - shapes
             required:
               - type
-              - source
         - if:
             properties:
               action:

--- a/onto_tool/ontograph.py
+++ b/onto_tool/ontograph.py
@@ -19,7 +19,6 @@ from time import perf_counter
 from urllib.parse import urlparse, urlunparse
 
 import pydot
-from SPARQLWrapper import JSON
 from rdflib import Graph, BNode
 from rdflib.namespace import RDF, OWL
 from rdflib.util import guess_format

--- a/onto_tool/ontograph.py
+++ b/onto_tool/ontograph.py
@@ -24,7 +24,7 @@ from rdflib import Graph, BNode
 from rdflib.namespace import RDF, OWL
 from rdflib.util import guess_format
 
-from .sparql_utils import create_endpoint
+from .sparql_utils import create_endpoint, select_query
 
 
 # Ignore \l - uses them as a line separator
@@ -88,16 +88,7 @@ class OntoGraf:
         logging.debug(f"Query\n {query}")
 
         sparql = create_endpoint(self.repo)
-
-        sparql.setQuery(query)
-        sparql.setReturnFormat(JSON)
-        results = sparql.query().convert()
-
-        for result in results["results"]["bindings"]:
-            yield dict(
-                (v, result[v]["value"])
-                for v in results["head"]["vars"] if v in result
-            )
+        return select_query(sparql, query)
 
     @staticmethod
     def strip_uri(uri):

--- a/onto_tool/ontograph.py
+++ b/onto_tool/ontograph.py
@@ -19,10 +19,12 @@ from time import perf_counter
 from urllib.parse import urlparse, urlunparse
 
 import pydot
-from SPARQLWrapper import SPARQLWrapper, POST, BASIC, JSON
+from SPARQLWrapper import JSON
 from rdflib import Graph, BNode
 from rdflib.namespace import RDF, OWL
 from rdflib.util import guess_format
+
+from .sparql_utils import create_endpoint
 
 
 # Ignore \l - uses them as a line separator
@@ -85,16 +87,7 @@ class OntoGraf:
         logging.debug(f"Query against {self.repo}")
         logging.debug(f"Query\n {query}")
 
-        repo_url = urlparse(self.repo)
-
-        sparql = SPARQLWrapper(urlunparse((repo_url.scheme,
-                                           re.sub('^.*@', '', repo_url.netloc),
-                                           repo_url.path,
-                                           '', '', '')))
-
-        sparql.setHTTPAuth(BASIC)
-        sparql.setCredentials(repo_url.username, repo_url.password)
-        sparql.setMethod(POST)
+        sparql = create_endpoint(self.repo)
 
         sparql.setQuery(query)
         sparql.setReturnFormat(JSON)

--- a/onto_tool/sparql_utils.py
+++ b/onto_tool/sparql_utils.py
@@ -1,0 +1,20 @@
+import re
+from urllib.parse import urlparse, urlunparse
+
+from SPARQLWrapper import SPARQLWrapper, POST, BASIC
+
+
+def create_endpoint(url, user=None, password=None) -> SPARQLWrapper:
+    repo_url = urlparse(url)
+
+    sparql = SPARQLWrapper(urlunparse((repo_url.scheme,
+                                       re.sub('^.*@', '', repo_url.netloc),
+                                       repo_url.path,
+                                       '', '', '')))
+
+    sparql.setHTTPAuth(BASIC)
+    sparql.setCredentials(user if user else repo_url.username,
+                          password if password else repo_url.password)
+    sparql.setMethod(POST)
+
+    return sparql

--- a/onto_tool/sparql_utils.py
+++ b/onto_tool/sparql_utils.py
@@ -1,7 +1,8 @@
 import re
 from urllib.parse import urlparse, urlunparse
+from typing import Iterator
 
-from SPARQLWrapper import SPARQLWrapper, POST, BASIC
+from SPARQLWrapper import SPARQLWrapper, POST, BASIC, JSON, CSV
 
 
 def create_endpoint(url, user=None, password=None) -> SPARQLWrapper:
@@ -18,3 +19,23 @@ def create_endpoint(url, user=None, password=None) -> SPARQLWrapper:
     sparql.setMethod(POST)
 
     return sparql
+
+
+def select_query(sparql: SPARQLWrapper, query: str) -> Iterator[dict]:
+    sparql.setQuery(query)
+    sparql.setReturnFormat(JSON)
+    results = sparql.query().convert()
+
+    for result in results["results"]["bindings"]:
+        yield dict(
+            (v, result[v]["value"])
+            for v in results["head"]["vars"] if v in result
+        )
+
+
+def select_query_csv(sparql: SPARQLWrapper, query: str) -> bytes:
+    sparql.setQuery(query)
+    sparql.setReturnFormat(CSV)
+    results = sparql.query().convert()
+
+    return results

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="onto_tool",
-    version="1.3.1",
+    version="1.4.0",
     author="Boris Pelakh",
     author_email="boris.pelakh@semanticarts.com",
     description="Ontology Maintenance and Release Tool",

--- a/tests/bundle/sparql.yaml
+++ b/tests/bundle/sparql.yaml
@@ -21,3 +21,4 @@ actions:
     source: '{output}/sparql.ttl'
     target: '{output}/sparql.csv'
     query: '{input}/bundle/test_sparql.rq'
+

--- a/tests/bundle/sparql_update.yaml
+++ b/tests/bundle/sparql_update.yaml
@@ -1,0 +1,42 @@
+bundle: test
+variables:
+  input: "tests/bundle"
+  output: "tests/bundle/endpoint_sparql"
+actions:
+  - action: 'mkdir'
+    directory: '{output}'
+  - action: 'sparql'
+    endpoint:
+      query_uri: 'https://agraph.semanticarts.com/catalogs/demo-catalog/repositories/ci-test'
+      user: 'ci-test-user'
+      password: 'ci-test-user'
+    query: "DROP GRAPH <http://example.com/bundle_sparql_test>"
+  - action: 'sparql'
+    endpoint:
+      query_uri: 'https://agraph.semanticarts.com/catalogs/demo-catalog/repositories/ci-test'
+      user: 'ci-test-user'
+      password: 'ci-test-user'
+    query: >
+      prefix skos: <http://www.w3.org/2004/02/skos/core#>
+      prefix : <http://example.com/>
+
+      INSERT {{
+        GRAPH :bundle_sparql_test {{ ?person skos:prefLabel ?name }}
+      }}
+      WHERE {{
+        VALUES (?person ?name) {{
+          (:John "John")
+          (:Jane "Jane")
+        }}
+      }}
+  - action: 'sparql'
+    endpoint:
+      query_uri: 'https://agraph.semanticarts.com/catalogs/demo-catalog/repositories/ci-test'
+      user: 'ci-test-user'
+      password: 'ci-test-user'
+    target: '{output}'
+    format: 'xml'
+    queries:
+      source: "{input}"
+      includes:
+        - "sparql_update_*.rq"

--- a/tests/bundle/sparql_update_construct.rq
+++ b/tests/bundle/sparql_update_construct.rq
@@ -1,0 +1,10 @@
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+prefix : <http://example.com/>
+
+CONSTRUCT {
+    ?person skos:prefLabel ?new_name
+}
+WHERE {
+    GRAPH :bundle_sparql_test { ?person skos:prefLabel ?name }
+    BIND(CONCAT(?name, " Johnson") as ?new_name)
+}

--- a/tests/bundle/sparql_update_select.rq
+++ b/tests/bundle/sparql_update_select.rq
@@ -1,0 +1,7 @@
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+prefix : <http://example.com/>
+
+select ?person ?name
+WHERE {
+    GRAPH :bundle_sparql_test { ?person skos:prefLabel ?name }
+}

--- a/tests/bundle/test_sparql.py
+++ b/tests/bundle/test_sparql.py
@@ -1,5 +1,7 @@
 from onto_tool import onto_tool
 import csv
+from rdflib import Graph, URIRef, Literal
+from rdflib.namespace import SKOS
 
 
 def lists_equal(list_one, list_two):
@@ -21,3 +23,26 @@ def test_sparql_queries():
          'o': 'urn:test-sparql-queries'}
     ]
     assert actual == expected
+
+
+def test_sparql_updates():
+    onto_tool.main([
+        'bundle', 'tests/bundle/sparql_update.yaml'
+    ])
+
+    with open('tests/bundle/endpoint_sparql/sparql_update_select.csv') as csvfile:
+        actual = list(row for row in csv.DictReader(csvfile))
+    expected = [
+        {'person': 'http://example.com/John',
+         'name': 'John'},
+        {'person': 'http://example.com/Jane',
+         'name': 'Jane'},
+    ]
+    assert actual == expected
+
+    constructed_graph = Graph()
+    constructed_graph.parse('tests/bundle/endpoint_sparql/sparql_update_construct.xml', format='xml')
+    labels = list(constructed_graph.subject_objects(SKOS.prefLabel))
+    assert lists_equal([(URIRef('http://example.com/John'), Literal('John Johnson')),
+                        (URIRef('http://example.com/Jane'), Literal('Jane Johnson'))],
+                       labels)

--- a/tests/bundle/test_verify.py
+++ b/tests/bundle/test_verify.py
@@ -95,6 +95,27 @@ def test_verify_construct(caplog):
     assert not isfile('test/bundle/verify_construct_results/verify_no_errors_construct_query.ttl')
 
 
+def test_verify_construct_endpoint(caplog):
+    with raises(SystemExit) as wrapped_exit:
+        onto_tool.main([
+            'bundle', 'tests/bundle/verify_construct_endpoint.yaml'
+        ])
+    assert wrapped_exit.type == SystemExit
+    assert wrapped_exit.value.code == 1
+
+    logs = caplog.text
+    assert re.search(r'Verification query .*verify_fixed_error', logs)
+    assert 'fails' in logs
+
+    validation_graph = Graph()
+    validation_graph.parse(
+        'tests/bundle/verify_construct_results/verify_fixed_error.ttl',
+        format='turtle')
+    sh = Namespace('http://www.w3.org/ns/shacl#')
+    errors = [validation_graph.subjects(RDF.type, sh.ValidationResult)]
+    assert len(errors) == 1
+
+
 def test_verify_shacl(caplog):
     with raises(SystemExit) as wrapped_exit:
         onto_tool.main([

--- a/tests/bundle/verify_construct_endpoint.yaml
+++ b/tests/bundle/verify_construct_endpoint.yaml
@@ -1,0 +1,14 @@
+bundle: test
+variables:
+  input: "tests/bundle"
+  output: "tests/bundle"
+actions:
+  - action: 'verify'
+    type: 'construct'
+    endpoint:
+      query_uri: 'https://agraph.semanticarts.com/catalogs/demo-catalog/repositories/ci-test'
+      user: 'ci-test-user'
+      password: 'ci-test-user'
+    target: '{output}/verify_construct_results'
+    stopOnFail: false
+    query: '{input}/verify_fixed_error.rq'

--- a/tests/bundle/verify_fixed_error.rq
+++ b/tests/bundle/verify_fixed_error.rq
@@ -1,0 +1,18 @@
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix sh: <http://www.w3.org/ns/shacl#>
+prefix : <http://example.com/>
+
+CONSTRUCT {
+    ?report a sh:ValidationReport ;
+        sh:conforms false ;
+        sh:result [ a sh:ValidationResult ;
+                sh:focusNode :fails ;
+                sh:resultMessage "Fake Violation Report" ;
+                sh:resultPath :fake_property ;
+                sh:resultSeverity sh:Violation ;
+                sh:value :fake_value ] .
+}
+WHERE {
+  bind(BNODE() as ?report)
+}


### PR DESCRIPTION
Tagging everyone assigned to the 10.x migration queries, since this is the tooling you will use to package the queries. Look specifically at the changes to `test_sparql.py` and `test_verify.py` to see how the new features are used.

This is failing verification right now because testing against an actual repo (`ci-test`) creates a race condition. I have previously created a `pytest` fixture that uses `rdflib` to emulate a SPARQL endpoint for an in-memory store, and as soon as I get a copy of it from Platts I will modify these unit tests to use it. Should be able to merge before we need it for the gist release.