### PR TITLE
Better instance graphics, bundle 'sparql' enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,15 @@ Graphics are exported both as ```png``` files and also as a ```dot``` file.  Thi
 ```
 usage: onto_tool graphic [-h] [-e ENDPOINT] [--schema | --data]
                          [--single-ontology-graphs] [--debug] [-o OUTPUT]
-                         [--show-shacl] [--instance-limit INSTANCE_LIMIT]
+                         [--show-shacl]
+                         [--link-concentrator-threshold LINK_CONCENTRATOR_THRESHOLD]
+                         [--instance-limit INSTANCE_LIMIT]
                          [--predicate-threshold PREDICATE_THRESHOLD]
                          [--include [INCLUDE ...] | --include-pattern
                          [INCLUDE_REGEX ...] | --exclude [EXCLUDE ...] |
                          --exclude-pattern [EXCLUDE_REGEX ...]] [-v VERSION]
-                         [-w [WEE [WEE ...]]] [--hide [HIDE [HIDE ...]]]
-                         [--no-image] [-t TITLE]
+                         [-w [WEE ...]] [--hide [HIDE ...]] [--no-image]
+                         [-t TITLE]
                          [ontology ...]
 
 positional arguments:
@@ -159,6 +161,11 @@ optional arguments:
                         sh:targetClass targeting, and can be confused by
                         complex logical shapes or Advanced SHACL features such
                         as SPARQL queries.
+  --link-concentrator-threshold LINK_CONCENTRATOR_THRESHOLD
+                        When the number links originating from the same class
+                        that share a single predicate exceed this threshold
+                        (default 10), use more compact display. Setting the
+                        value to 0 disables this behavior.
   -v VERSION, --version VERSION
                         Version to place in graphic
   -w [WEE ...], --wee [WEE ...]

--- a/README.md
+++ b/README.md
@@ -385,6 +385,33 @@ emitted as a `INFO`-level log message prior to the execution of the action.
   stored as either Turtle, RDF/XML or N-Triples, depending on the `format` option (`turtle`, `xml`, or `nt`).
       Update queries will alter the input data in place, and the resulting
       graph will be output in the specified format.
+    * `UPDATE` queries executed on local files will modify the in-memory graph and then serialize the
+      resulting graph to the `target`.
+    * The default functionality is to combine all RDF sources specified via `includes`
+      and execute queries on the resulting graph. However, if `eachFile: true` is added,
+      all queries will be applied to each source file separately, and will produce a 
+      separate output file. In this case, `target` will be treated as a directory, and
+      the `rename` option should be used when needed to construct the output file names. For example, the following
+      action extracts the labels out of each RDF file into a separate CSV with matching names:
+      ```yaml
+      - action: 'sparql'
+        message: "Multi-file processing with SELECT"
+        eachFile: true
+        source: '{input}'
+        includes:
+          - '*_ontology.ttl'
+        target: "{output}/each/select"
+        rename:
+          from: "(.*)\\.ttl"
+          to: "\\g<1>.csv"
+        query: >
+          prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+          prefix skos: <http://www.w3.org/2004/02/skos/core#>
+          select ?label
+          WHERE {{
+            ?s rdfs:label ?label .
+          }} order by ?label
+      ```
     * As an alternative to operating on local RDF specified via 'source', a query can
       be executed on a triple store by specifying an `endpoint`, which must
       contain a `query_uri`, and can optionally specify `user`/`password` which will

--- a/onto_tool/__init__.py
+++ b/onto_tool/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '1.5.0'
+VERSION = '1.6.0'

--- a/onto_tool/bundle_schema.yaml
+++ b/onto_tool/bundle_schema.yaml
@@ -327,6 +327,8 @@ properties:
                       $ref: '#/definitions/non_empty_string'
                     includes:
                       $ref: '#/definitions/include_list'
+                    eachFile:
+                      type: boolean
                     format:
                       type: string
                       enum:

--- a/onto_tool/command_line.py
+++ b/onto_tool/command_line.py
@@ -190,6 +190,10 @@ def configure_arg_parser():
                                      " SHACL shapes and colors them green on the graph. This detection relies"
                                      " on the presence of sh:targetClass targeting, and can be confused by"
                                      " complex logical shapes or Advanced SHACL features such as SPARQL queries.")
+    graphic_parser.add_argument("--link-concentrator-threshold", type=int, default=3,
+                                help="When the number links originating from the same class that share a "
+                                     "single predicate exceed this threshold (default 10), use more compact "
+                                     "display. Setting the value to 0 disables this behavior.")
     sampling_limits = graphic_parser.add_argument_group(title='Sampling Limits')
     sampling_limits.add_argument("--instance-limit", type=int, default=500000,
                                  help="Specify a limit on how many triples to consider that use any one"

--- a/onto_tool/onto_tool.py
+++ b/onto_tool/onto_tool.py
@@ -402,7 +402,7 @@ def __perform_export__(output, output_format, paths, context=None,
                        versioned=versioned_defined_by)
 
     serialized = g.serialize(format=output_format)
-    output.write(serialized.decode(output.encoding))
+    output.write(serialized)
 
 
 class VarDict(dict):
@@ -1238,7 +1238,7 @@ def output_updated_ontology(args, g, onto_file, orig_format, output_format):
                     encoding='utf-8')
     else:
         serialized = g.serialize(format=output_format)
-        args.output.write(serialized.decode(args.output.encoding))
+        args.output.write(serialized)
 
 
 def main(arguments):

--- a/onto_tool/onto_tool.py
+++ b/onto_tool/onto_tool.py
@@ -306,6 +306,9 @@ def generate_graphic(action, onto_files, endpoint, **kwargs):
         named graphs are matched for exclusion from a data graph.
     show_shacl: boolean
         If True, attempt to detect SHACL shapes matching classes and properties.
+    concentrate_links: int
+        When the number links originating from the same class that share a single predicate exceed this threshold,
+        use more compact display. Setting the value to 0 disables this behavior.
 
     Returns
     -------
@@ -1328,6 +1331,7 @@ def main(arguments):
                          single_graph=args.single_ontology_graphs,
                          wee=args.wee, outpath=args.output, version=args.version,
                          no_image=args.no_image, title=args.title, hide=args.hide,
+                         concentrate_links=args.link_concentrator_threshold,
                          include=args.include, exclude=args.exclude,
                          include_pattern=args.include_pattern,
                          exclude_pattern=args.exclude_pattern,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-rdflib[sparql]>=5.0.0
-pyshacl~=0.14.0
+rdflib>=6.0.0
+pyshacl~=0.17.0
 pydot>=1.4.1
 jinja2>=2.11.2
 markdown>=3.2.1

--- a/tests/bundle/sparql-each.yaml
+++ b/tests/bundle/sparql-each.yaml
@@ -1,0 +1,64 @@
+bundle: test
+variables:
+  # Using inputs form tests/graphic as they offer convenient patters
+  input: "tests/graphic"
+  output: "tests/bundle"
+actions:
+  - action: 'mkdir'
+    directory: "{output}/each/construct"
+  - action: 'sparql'
+    message: "Multi-file processing with CONSTRUCT"
+    eachFile: true
+    source: '{input}'
+    includes:
+      - '*_ontology.ttl'
+    target: "{output}/each/construct"
+    query: >
+      prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      prefix skos: <http://www.w3.org/2004/02/skos/core#>
+      construct {{
+        ?s skos:prefLabel ?label
+      }}
+      WHERE {{
+        ?s rdfs:label ?label .
+      }}
+  - action: 'mkdir'
+    directory: "{output}/each/select"
+  - action: 'sparql'
+    message: "Multi-file processing with SELECT"
+    eachFile: true
+    source: '{input}'
+    includes:
+      - '*_ontology.ttl'
+    target: "{output}/each/select"
+    rename:
+      from: "(.*)\\.ttl"
+      to: "\\g<1>.csv"
+    query: >
+      prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      prefix skos: <http://www.w3.org/2004/02/skos/core#>
+      select ?label
+      WHERE {{
+        ?s rdfs:label ?label .
+      }} order by ?label
+  - action: 'mkdir'
+    directory: "{output}/each/update"
+  - action: 'sparql'
+    message: "Multi-file processing with UPDATE"
+    eachFile: true
+    source: '{input}'
+    includes:
+      - '*_ontology.ttl'
+    target: "{output}/each/update"
+    query: >
+      prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      prefix skos: <http://www.w3.org/2004/02/skos/core#>
+      delete {{
+        ?s rdfs:label ?label
+      }}
+      insert {{
+        ?s skos:prefLabel ?label
+      }}
+      WHERE {{
+        ?s rdfs:label ?label .
+      }}

--- a/tests/graphic/concentration.ttl
+++ b/tests/graphic/concentration.ttl
@@ -1,0 +1,32 @@
+@prefix : <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+:Bugs
+	a :Rabbit ;
+	:playsWith
+		:Pepe ,
+		:Porky ,
+		:Sylvester ,
+		:Tweety
+		;
+	.
+
+:Pepe
+	a :Skunk ;
+	.
+
+:Porky
+	a :Pig ;
+	.
+
+:Sylvester
+	a :Cat ;
+	.
+
+:Tweety
+	a :Bird ;
+	.
+

--- a/tests/graphic/inheritance_hierarchy.ttl
+++ b/tests/graphic/inheritance_hierarchy.ttl
@@ -1,0 +1,121 @@
+@prefix : <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:AEP
+	a
+		:Fraternity ,
+		:Organization
+		;
+	.
+
+:AloofAcademic
+	a
+		:Person ,
+		:Professor
+		;
+	:age "50"^^xsd:integer ;
+	:memberOf :TuesdayBookClub ;
+	:residesAt :ResplendentMansion ;
+	.
+
+:Apartment
+	a owl:Class ;
+	rdfs:subClassOf :Location ;
+	.
+
+:CheapHovel
+	a
+		:Apartment ,
+		:Location
+		;
+	.
+
+:Costco
+	a :Organization ;
+	.
+
+:Fraternity
+	a owl:Class ;
+	rdfs:subClassOf :Organization ;
+	.
+
+:GrimGradStudent
+	a
+		:Person ,
+		:Student
+		;
+	:age "25"^^xsd:integer ;
+	:memberOf
+		:AEP ,
+		:Costco
+		;
+	:residesAt :CheapHovel ;
+	.
+
+:Location
+	a owl:Class ;
+	.
+
+:Organization
+	a owl:Class ;
+	.
+
+:Person
+	a owl:Class ;
+	.
+
+:Professor
+	a owl:Class ;
+	rdfs:subClassOf :Person ;
+	.
+
+:ResplendentMansion
+	a
+		:Location ,
+		:SingleFamilyHome
+		;
+	.
+
+:SingleFamilyHome
+	a owl:Class ;
+	rdfs:subClassOf :Location ;
+	.
+
+:SocialClub
+	a owl:Class ;
+	rdfs:subClassOf :Organization ;
+	.
+
+:Student
+	a owl:Class ;
+	rdfs:subClassOf :Person ;
+	.
+
+:Townie
+	a :Person ;
+	:age "35"^^xsd:integer ;
+	:memberOf :Costco ;
+	.
+
+:TuesdayBookClub
+	a
+		:Organization ,
+		:SocialClub
+		;
+	.
+
+:age
+	a owl:DatatypeProperty ;
+	.
+
+:memberOf
+	a owl:ObjectProperty ;
+	.
+
+:residesAt
+	a owl:ObjectProperty ;
+	.
+

--- a/tests/graphic/test_instance.py
+++ b/tests/graphic/test_instance.py
@@ -31,15 +31,15 @@ def test_inheritance():
                        'tests/graphic/inheritance_hierarchy.ttl'
                    ])
     (instance_graph,) = pydot.graph_from_dot_file('tests/graphic/test_inheritance.dot')
-    edges = list(sorted((e.get_source(), e.get_label(), e.get_destination()) for e in instance_graph.get_edges()))
+    edges = list(sorted((e.get_source(), e.get_label() or '', e.get_destination()) for e in instance_graph.get_edges()))
     assert edges == [
         ('"http://example.org/Person"', 'memberOf', '"http://example.org/Organization"'),
+        ('"http://example.org/Professor"', '', '"http://example.org/Person"'),
         ('"http://example.org/Professor"', 'memberOf', '"http://example.org/SocialClub"'),
         ('"http://example.org/Professor"', 'residesAt', '"http://example.org/SingleFamilyHome"'),
-        ('"http://example.org/Professor"', 'subClassOf', '"http://example.org/Person"'),
+        ('"http://example.org/Student"', '', '"http://example.org/Person"'),
         ('"http://example.org/Student"', 'memberOf', '"http://example.org/Fraternity"'),
-        ('"http://example.org/Student"', 'residesAt', '"http://example.org/Apartment"'),
-        ('"http://example.org/Student"', 'subClassOf', '"http://example.org/Person"')
+        ('"http://example.org/Student"', 'residesAt', '"http://example.org/Apartment"')
     ]
     assert 'age' in instance_graph.get_node('"http://example.org/Person"')[0].get_label()
     assert 'age' not in instance_graph.get_node('"http://example.org/Student"')[0].get_label()

--- a/tests/graphic/test_instance.py
+++ b/tests/graphic/test_instance.py
@@ -5,11 +5,14 @@ import pydot
 
 def test_local_instance():
     onto_tool.main([
-                       'graphic', '--predicate-threshold', '0', '--data',
-                       '-t', 'Local Instance Data',
-                       '--no-image',
-                       '-o', 'tests/graphic/test_instance'
-                   ] + glob.glob('tests/graphic/*.ttl'))
+        'graphic', '--predicate-threshold', '0', '--data',
+        '-t', 'Local Instance Data',
+        '--no-image',
+        '-o', 'tests/graphic/test_instance',
+        'tests/graphic/domain_ontology.ttl',
+        'tests/graphic/upper_ontology.ttl',
+        'tests/graphic/instance_data.ttl'
+    ])
     (instance_graph,) = pydot.graph_from_dot_file('tests/graphic/test_instance.dot')
     edges = list(sorted((e.get_source(), e.get_destination()) for e in instance_graph.get_edges()))
     assert edges == [
@@ -17,6 +20,29 @@ def test_local_instance():
         ('"http://example.com/Teacher"', '"http://example.com/School"'),
         ('"http://example.com/Teacher"', '"http://example.com/Student"')
     ]
+
+
+def test_inheritance():
+    onto_tool.main([
+                       'graphic', '--predicate-threshold', '0', '--data',
+                       '-t', 'Inheritance is Difficult',
+                       '--no-image',
+                       '-o', 'tests/graphic/test_inheritance',
+                       'tests/graphic/inheritance_hierarchy.ttl'
+                   ])
+    (instance_graph,) = pydot.graph_from_dot_file('tests/graphic/test_inheritance.dot')
+    edges = list(sorted((e.get_source(), e.get_label(), e.get_destination()) for e in instance_graph.get_edges()))
+    assert edges == [
+        ('"http://example.org/Person"', 'memberOf', '"http://example.org/Organization"'),
+        ('"http://example.org/Professor"', 'memberOf', '"http://example.org/SocialClub"'),
+        ('"http://example.org/Professor"', 'residesAt', '"http://example.org/SingleFamilyHome"'),
+        ('"http://example.org/Professor"', 'subClassOf', '"http://example.org/Person"'),
+        ('"http://example.org/Student"', 'memberOf', '"http://example.org/Fraternity"'),
+        ('"http://example.org/Student"', 'residesAt', '"http://example.org/Apartment"'),
+        ('"http://example.org/Student"', 'subClassOf', '"http://example.org/Person"')
+    ]
+    assert 'age' in instance_graph.get_node('"http://example.org/Person"')[0].get_label()
+    assert 'age' not in instance_graph.get_node('"http://example.org/Student"')[0].get_label()
 
 
 def test_verify_construct(caplog):

--- a/tests/graphic/test_instance.py
+++ b/tests/graphic/test_instance.py
@@ -54,3 +54,29 @@ def test_verify_construct(caplog):
                    ] + glob.glob('tests/graphic/*_ontology.ttl'))
     logs = caplog.text
     assert 'No data found' in logs
+
+
+def test_concentration():
+    # First, with concentration
+    onto_tool.main([
+        'graphic', '--predicate-threshold', '0', '--data',
+        '--debug',
+        '-t', 'Looney Tunes',
+        '--no-image',
+        '-o', 'tests/graphic/concentration',
+        'tests/graphic/concentration.ttl'
+    ])
+    (instance_graph,) = pydot.graph_from_dot_file('tests/graphic/concentration.dot')
+    assert 1 == sum(1 for e in instance_graph.get_edges() if e.get_label() == 'playsWith')
+
+    # Then, without
+    onto_tool.main([
+        'graphic', '--predicate-threshold', '0', '--data',
+        '-t', 'Looney Tunes',
+        '--no-image',
+        '--link-concentrator-threshold', '0',
+        '-o', 'tests/graphic/concentration',
+        'tests/graphic/concentration.ttl'
+    ])
+    (instance_graph,) = pydot.graph_from_dot_file('tests/graphic/concentration.dot')
+    assert 4 == sum(1 for e in instance_graph.get_edges() if e.get_label() == 'playsWith')

--- a/tests/graphic/test_schema.py
+++ b/tests/graphic/test_schema.py
@@ -5,11 +5,14 @@ import pydot
 
 def test_local_instance():
     onto_tool.main([
-                       'graphic',
-                       '-t', 'Local Ontology',
-                       '--no-image',
-                       '-o', 'tests/graphic/test_schema'
-                   ] + glob.glob('tests/graphic/*.ttl'))
+        'graphic',
+        '-t', 'Local Ontology',
+        '--no-image',
+        '-o', 'tests/graphic/test_schema',
+        'tests/graphic/domain_ontology.ttl',
+        'tests/graphic/upper_ontology.ttl',
+        'tests/graphic/instance_data.ttl'
+    ])
     (instance_graph,) = pydot.graph_from_dot_file('tests/graphic/test_schema.dot')
     edges = list(sorted((e.get_source(), e.get_destination()) for e in instance_graph.get_edges()))
     assert edges == [


### PR DESCRIPTION
* `graphics --data` improvements
  * Construct class hierarchy so that the most specific class available can be used in links
  * Push links and attributes to super classes when possible to create less busy graphs
  * Size nodes based on the instance counts (when applying `--include`/`--exclude` filters
* New `eachFile` functionality for the bundle `'sparql'` action - see README documentation.
* Fixed dependencies, general tidying up.