### PR TITLE
Support --label-language, documentation and test updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ will install the `onto_tool` command and all its dependencies into your environm
 
 ```
 $ onto_tool -h
-usage: onto_tool [-h] {update,export,bundle,graphic} ...
+usage: onto_tool [-h] [-k] [-v] {update,export,bundle,graphic} ...
 
 Ontology toolkit.
 
@@ -25,11 +25,12 @@ positional arguments:
     update              Update versions and dependencies
     export              Export ontology
     bundle              Bundle ontology for release
-    graphic             Create PNG graphic and dot file from OWL files
+    graphic             Create PNG graphic and dot file from OWL files or SPARQL Endpoint
 
 optional arguments:
   -h, --help            show this help message and exit
   -k, --insecure        Allow insecure server connections when using SSL
+  -v, --version         Report onto-tool version and exit
 ```
 
 ## Sub-Commands
@@ -130,12 +131,15 @@ usage: onto_tool graphic [-h] [-e ENDPOINT] [--schema | --data]
                          [--link-concentrator-threshold LINK_CONCENTRATOR_THRESHOLD]
                          [--instance-limit INSTANCE_LIMIT]
                          [--predicate-threshold PREDICATE_THRESHOLD]
-                         [--include [INCLUDE ...] | --include-pattern
-                         [INCLUDE_REGEX ...] | --exclude [EXCLUDE ...] |
-                         --exclude-pattern [EXCLUDE_REGEX ...]] [-v VERSION]
-                         [-w [WEE ...]] [--hide [HIDE ...]] [--no-image]
-                         [-t TITLE]
-                         [ontology ...]
+                         [--include [INCLUDE [INCLUDE ...]] |
+                         --include-pattern [INCLUDE_REGEX [INCLUDE_REGEX ...]]
+                         | --exclude [EXCLUDE [EXCLUDE ...]] |
+                         --exclude-pattern
+                         [EXCLUDE_REGEX [EXCLUDE_REGEX ...]]] [-v VERSION]
+                         [-w [WEE [WEE ...]]]
+                         [--label-language LABEL_LANGUAGE]
+                         [--hide [HIDE [HIDE ...]]] [--no-image] [-t TITLE]
+                         [ontology [ontology ...]]
 
 positional arguments:
   ontology              Ontology file, directory or name pattern
@@ -168,10 +172,14 @@ optional arguments:
                         value to 0 disables this behavior.
   -v VERSION, --version VERSION
                         Version to place in graphic
-  -w [WEE ...], --wee [WEE ...]
+  -w [WEE [WEE ...]], --wee [WEE [WEE ...]]
                         For ontologies matching the patterns specified, only
                         render the name and import information. If no patterns
-                        are specified, applies to all onotologies.
+                        are specified, applies to all ontologies.
+  --label-language LABEL_LANGUAGE
+                        In case entities have labels in multiple languages,
+                        select either the specified language (default: en) or
+                        a non-lanugage label.
   --hide [HIDE [HIDE ...]]
                         When visualizing data, hide classes and properties
                         matching the regexpatterns specified with this option.

--- a/onto_tool/__init__.py
+++ b/onto_tool/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '1.6.0'
+VERSION = '1.7.0'

--- a/onto_tool/command_line.py
+++ b/onto_tool/command_line.py
@@ -238,6 +238,9 @@ def configure_arg_parser():
                                 help="For ontologies matching the patterns specified, only render "
                                      "the name and import information. If no patterns are specified, applies "
                                      "to all ontologies.")
+    graphic_parser.add_argument('--label-language', action="store", default="en",
+                                help="In case entities have labels in multiple languages, select either "
+                                     "the specified language (default: en) or a non-lanugage label.")
     graphic_parser.add_argument('--hide', nargs="*", default=[],
                                 help="When visualizing data, hide classes and properties matching the regex"
                                      "patterns specified with this option.")

--- a/onto_tool/onto_tool.py
+++ b/onto_tool/onto_tool.py
@@ -292,6 +292,8 @@ def generate_graphic(action, onto_files, endpoint, **kwargs):
         Path of directory where graph will be output.
     version : string
         Version to be used in graphic title.
+    label_language: string
+        When multiple language labels are present, use this one.
     hide: list(string)
         List of regular expressions to control which classes and/or properties will be hidden from the data graphic.
     include: list(string)
@@ -1331,6 +1333,7 @@ def main(arguments):
                          single_graph=args.single_ontology_graphs,
                          wee=args.wee, outpath=args.output, version=args.version,
                          no_image=args.no_image, title=args.title, hide=args.hide,
+                         label_language=args.label_language,
                          concentrate_links=args.link_concentrator_threshold,
                          include=args.include, exclude=args.exclude,
                          include_pattern=args.include_pattern,

--- a/onto_tool/ontograph.py
+++ b/onto_tool/ontograph.py
@@ -825,7 +825,7 @@ class OntoGraf:
                                   arrowhead='normal')
                 self.graf.add_edge(edge)
 
-        self.graf.write(self.outdot)
+        self.graf.write(self.outdot, encoding="utf-8")
         if not self.no_image:
             self.graf.write_png(self.outpng)
         logging.debug("Plots saved")

--- a/tests/graphic/multi_language.ttl
+++ b/tests/graphic/multi_language.ttl
@@ -1,0 +1,9 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix : <http://example.com/> .
+
+:Bill a :Person; :likes :Cake .
+:likes a owl:ObjectProperty; rdfs:label "likes"@en, "aime"@fr .
+:Cake a :Dessert .

--- a/tests/graphic/test_instance.py
+++ b/tests/graphic/test_instance.py
@@ -22,6 +22,34 @@ def test_local_instance():
     ]
 
 
+def test_multi_language():
+    onto_tool.main([
+        'graphic', '--predicate-threshold', '0', '--data',
+        '-t', 'Multi Language Labels',
+        '--no-image',
+        '-o', 'tests/graphic/test_multi_lingual_en',
+        'tests/graphic/multi_language.ttl'
+    ])
+    (instance_graph,) = pydot.graph_from_dot_file('tests/graphic/test_multi_lingual_en.dot')
+    edges = list(sorted((e.get_source(), e.get_label(), e.get_destination()) for e in instance_graph.get_edges()))
+    assert edges == [
+        ('"http://example.com/Person"', 'likes', '"http://example.com/Dessert"')
+    ]
+
+    onto_tool.main([
+        'graphic', '--predicate-threshold', '0', '--data',
+        '-t', 'Multi Language Labels',
+        '--no-image', '--label-language', 'fr',
+        '-o', 'tests/graphic/test_multi_lingual_fr',
+        'tests/graphic/multi_language.ttl'
+    ])
+    (instance_graph,) = pydot.graph_from_dot_file('tests/graphic/test_multi_lingual_fr.dot')
+    edges = list(sorted((e.get_source(), e.get_label(), e.get_destination()) for e in instance_graph.get_edges()))
+    assert edges == [
+        ('"http://example.com/Person"', 'aime', '"http://example.com/Dessert"')
+    ]
+
+
 def test_inheritance():
     onto_tool.main([
                        'graphic', '--predicate-threshold', '0', '--data',


### PR DESCRIPTION
Made further changes to get WHOI data to render - specifically, had to handle multi-lingual labels on properties and classes, and literals without datatypes, which had to default to `xsd:string`. After all the change, using this command
```
onto_tool -k graphic -e https://lod.bco-dmo.org/sparql --data --instance-limit 10000 
```
produced the attached image. There is quite a bit more to do to improve this - consolidating targets w/ subclasses (such as all the Role sub-classes), hiding some inverses, etc. But the picture does emerge.
![image](https://user-images.githubusercontent.com/3536929/137836744-645ac9c7-7289-4f42-bd09-6aacd3c30024.png)
