### PR TITLE
Support strict/full/all for definedBy. Fixes #105.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,10 @@ optional arguments:
 
 The `export` sub-command will transform the ontology into the desired format, and remove version information, as required by tools such as Top Braid Composer.
 ```
-usage: onto_tool export [-h] [-f {xml,turtle,nt} | -c CONTEXT] [--debug]
-                        [-o OUTPUT] [-s] [-m IRI VERSION] [-b [{all,strict}]]
-                        [--retain-definedBy] [--versioned-definedBy]
+usage: onto_tool update [-h] [-f {xml,turtle,nt} | -i] [--debug] [-o OUTPUT]
+                        [-b [{all,full,strict}]] [--retain-definedBy]
+                        [--versioned-definedBy] [-v SET_VERSION]
+                        [--version-info [VERSION_INFO]] [-d DEPENDENCY VERSION]
                         [ontology [ontology ...]]
 
 positional arguments:
@@ -94,24 +95,28 @@ optional arguments:
   -h, --help            show this help message and exit
   -f {xml,turtle,nt}, --format {xml,turtle,nt}
                         Output format
-  -c CONTEXT, --context CONTEXT
-                        Export as N-Quads in CONTEXT.
+  -i, --in-place        Overwrite each input file with update, preserving format
   --debug               Emit verbose debug output
   -o OUTPUT, --output OUTPUT
-                        Path to output file.
-  -s, --strip-versions  Remove versions from imports.
-  -m IRI VERSION, --merge IRI VERSION
-                        Merge all inputs into a single ontology with the given
-                        IRI and version
-  -b [{all,strict}], --defined-by [{all,strict}]
-                        Add rdfs:isDefinedBy to every resource defined. If the
-                        (default) "strict" argument is provided, only
-                        owl:Class, owl:ObjectProperty, owl:DatatypeProperty,
-                        owl:AnnotationProperty and owl:Thing entities will be
-                        annotated. If "all" is provided, every entity that has
-                        any properties other than rdf:type will be annotated.
-  --retain-definedBy    When merging ontologies, retain existing values of
-                        rdfs:isDefinedBy
+                        Path to output file. Will be ignored if --in-place is specified.
+  -b [{all,full,strict}], --defined-by [{all,full,strict}]
+                        Add rdfs:isDefinedBy to every resource defined. If the (default)
+                        "strict" argument is provided, only owl:Class, owl:ObjectProperty,
+                        owl:DatatypeProperty, owl:AnnotationProperty and owl:Thing entities
+                        will be annotated. If "full" is provided, every entity that has any
+                        properties other than rdf:type will be annotated. If "all" is
+                        provided, every entity will be annotated. Will override any
+                        existing rdfs:isDefinedBy annotations on the affected entities
+                        unless --retain-definedBy is specified.
+  --retain-definedBy    Retain existing values of rdfs:isDefinedBy
+  --versioned-definedBy
+                        Use versionIRI for rdfs:isDefinedBy, when available
+  -v SET_VERSION, --set-version SET_VERSION
+                        Set the version of the defined ontology
+  --version-info [VERSION_INFO]
+                        Adjust versionInfo, defaults to "Version X.x.x"
+  -d DEPENDENCY VERSION, --dependency-version DEPENDENCY VERSION
+                        Update the import of DEPENDENCY to VERSION
 ```
 
 ### Graphic
@@ -358,9 +363,12 @@ emitted as a `INFO`-level log message prior to the execution of the action.
 ##### RDF Transformation
 
 - `definedBy`, which inspects each input file to identify a single defined ontology, and then
-  adds a `rdfs:isDefinedBy` property to every `owl:Class`, `owl:ObjectProperty`, `owl:DatatypeProperty`
-  and `owl:AnnotationProperty` defined in the file referencing the identified ontology. Existing
-  `rdfs:isDefinedBy` values are removed prior to the addition. Input and output file specification
+  adds a `rdfs:isDefinedBy` property to entities defined within that input file. If `mode` is
+  set to `strict` (default), the annotation is applied to every `owl:Class`, `owl:ObjectProperty`,
+  `owl:DatatypeProperty` and `owl:AnnotationProperty`. If `mode` is `full`, annotations are applied
+  to all entities that have any attributes other than `rdf:type`, and setting the mode to `all`
+  results in all entities receiving the annotation. Existing `rdfs:isDefinedBy` values are removed
+  prior to the addition. Input and output file specification
   options are identical to those used by the `copy` action.
 - `export`, which functions similarly to the command-line export functionality, gathering one or
   more input ontologies and exporting them as a single file, with some optional transformations,

--- a/onto_tool/bundle_schema.yaml
+++ b/onto_tool/bundle_schema.yaml
@@ -419,6 +419,12 @@ properties:
                     type: boolean
                   versionedDefinedBy:
                     type: boolean
+                  mode:
+                    type: string
+                    enum:
+                      - strict
+                      - full
+                      - all
         - if:
             properties:
               action:

--- a/onto_tool/command_line.py
+++ b/onto_tool/command_line.py
@@ -86,13 +86,14 @@ def configure_arg_parser():
                                '--in-place is specified.')
     update_parser.add_argument('-b', '--defined-by', action="store",
                                nargs="?", const='strict',
-                               choices=['all', 'strict'],
+                               choices=['all', 'full', 'strict'],
                                help='Add rdfs:isDefinedBy to every resource defined. '
                                'If the (default) "strict" argument is provided, only '
                                'owl:Class, owl:ObjectProperty, owl:DatatypeProperty, '
                                'owl:AnnotationProperty and owl:Thing entities will be '
-                               'annotated. If "all" is provided, every entity that has '
+                               'annotated. If "full" is provided, every entity that has '
                                'any properties other than rdf:type will be annotated. '
+                               'If "all" is provided, every entity will be annotated. '
                                'Will override any existing rdfs:isDefinedBy annotations '
                                'on the affected entities unless --retain-definedBy is '
                                'specified.')

--- a/tests/bundle/defined_by.ttl
+++ b/tests/bundle/defined_by.ttl
@@ -1,0 +1,14 @@
+@prefix : <https://data.clientX.com/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+:MyIndividual a :Resource ;
+    skos:prefLabel "Tom" .
+
+:myProperty a owl:DatatypeProperty ;
+    skos:prefLabel "my property" .
+
+:randomStub a :Stub .
+
+<https://data.clientX.com/d/ontoName>
+    a owl:Ontology .

--- a/tests/bundle/defined_by.yaml
+++ b/tests/bundle/defined_by.yaml
@@ -1,0 +1,25 @@
+bundle: test
+variables:
+  input: "tests"
+  output: "tests/bundle"
+actions:
+- action: "definedBy"
+  message: "Adding default rdfs:isDefinedBy."
+  source: "{input}/bundle/defined_by.ttl"
+  target: "{output}/defined_by_default.ttl"
+- action: "definedBy"
+  message: "Adding strict rdfs:isDefinedBy."
+  source: "{input}/bundle/defined_by.ttl"
+  target: "{output}/defined_by_strict.ttl"
+  mode: "strict"
+- action: "definedBy"
+  message: "Adding full rdfs:isDefinedBy."
+  source: "{input}/bundle/defined_by.ttl"
+  target: "{output}/defined_by_full.ttl"
+  mode: "full"
+- action: "definedBy"
+  message: "Adding all rdfs:isDefinedBy."
+  source: "{input}/bundle/defined_by.ttl"
+  target: "{output}/defined_by_all.ttl"
+  mode: "all"
+

--- a/tests/bundle/test_defined_by.py
+++ b/tests/bundle/test_defined_by.py
@@ -1,0 +1,53 @@
+from onto_tool import onto_tool
+import csv
+from rdflib import Graph, URIRef, Literal
+from rdflib.namespace import RDFS, SKOS
+
+
+def lists_equal(list_one, list_two):
+    return len(list_one) == len(list_two) and sorted(list_one) == sorted(list_two)
+
+
+def test_defined_by():
+    onto_tool.main([
+        'bundle', '-v', 'output', 'tests-output/bundle', 'tests/bundle/defined_by.yaml'
+    ])
+
+    # Verify default
+    output_graph = Graph()
+    output_graph.parse(
+        'tests-output/bundle/defined_by_default.ttl', format='turtle')
+    defined = list(output_graph.subject_objects(RDFS.isDefinedBy))
+    assert lists_equal(defined,
+                       [(URIRef('https://data.clientX.com/myProperty'),
+                         URIRef('https://data.clientX.com/d/ontoName'))])
+    # Verify strict
+    output_graph = Graph()
+    output_graph.parse(
+        'tests-output/bundle/defined_by_strict.ttl', format='turtle')
+    defined = list(output_graph.subject_objects(RDFS.isDefinedBy))
+    assert lists_equal(defined,
+                       [(URIRef('https://data.clientX.com/myProperty'),
+                         URIRef('https://data.clientX.com/d/ontoName'))])
+    # Verify full
+    output_graph = Graph()
+    output_graph.parse(
+        'tests-output/bundle/defined_by_full.ttl', format='turtle')
+    defined = list(output_graph.subject_objects(RDFS.isDefinedBy))
+    assert lists_equal(defined,
+                       [(URIRef('https://data.clientX.com/myProperty'),
+                         URIRef('https://data.clientX.com/d/ontoName')),
+                        (URIRef('https://data.clientX.com/MyIndividual'),
+                         URIRef('https://data.clientX.com/d/ontoName'))])
+    # Verify all
+    output_graph = Graph()
+    output_graph.parse(
+        'tests-output/bundle/defined_by_all.ttl', format='turtle')
+    defined = list(output_graph.subject_objects(RDFS.isDefinedBy))
+    assert lists_equal(defined,
+                       [(URIRef('https://data.clientX.com/myProperty'),
+                         URIRef('https://data.clientX.com/d/ontoName')),
+                        (URIRef('https://data.clientX.com/MyIndividual'),
+                         URIRef('https://data.clientX.com/d/ontoName')),
+                        (URIRef('https://data.clientX.com/randomStub'),
+                         URIRef('https://data.clientX.com/d/ontoName'))])


### PR DESCRIPTION
* Add a `full` mode to replace what the old `all` mode used to do (add `rdfs:isDefinedBy` to any entity that has attributes in addition to `rdf:type`)
* Modify `all` to annotate any entity that has a type, even if it's the only attribute.
* Add a `mode` attribute to the bundle `definedBy` action so that the full functionality is available from bundles.

Address #105 and enable https://github.com/semanticarts/gist/issues/775.

Since this modifies the behavior of the command-line interface, it would require a major release. Will probably hold until we can fold in a few other interface-breaking or substantial changes.