### PR TITLE
Version 1.8.0 - new excludes functionality

### DIFF
--- a/onto_tool/__init__.py
+++ b/onto_tool/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '1.7.4'
+VERSION = '1.8.0'

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,5 @@ setuptools.setup(
             "onto_tool = onto_tool.onto_tool:run_tool"
         ]
     },
-    python_requires='>=3.7',
+    python_requires='>=3.8',
 )


### PR DESCRIPTION
Bump version, and change Python dependency to >=3.8, as Python 3.7 is no longer supported.