### PR TITLE
Draft: Cache graphic query results

### DIFF
--- a/onto_tool/command_line.py
+++ b/onto_tool/command_line.py
@@ -165,8 +165,12 @@ def configure_arg_parser():
     graphic_parser = subparsers.add_parser('graphic',
                                            help='Create PNG graphic and dot'
                                            ' file from OWL files or SPARQL Endpoint')
-    graphic_parser.add_argument("-e", "--endpoint", action="store",
+    data_source_group = graphic_parser.add_argument_group(title="Remote data source")
+    data_source = data_source_group.add_mutually_exclusive_group()
+    data_source.add_argument("-e", "--endpoint", action="store",
                                 help="URI of SPARQL endpoint to use to gather data")
+    data_source.add_argument("--cache", type=argparse.FileType("r"),
+                                help="Use cached data from previous queries")
     which_graphic = graphic_parser.add_mutually_exclusive_group()
     which_graphic.add_argument("--schema", dest="action", action="store_const",
                                const="ontology", default="ontology",
@@ -182,6 +186,8 @@ def configure_arg_parser():
                                      " entities defined by each ontology.")
     graphic_parser.add_argument('--debug', action="store_true",
                                 help="Emit verbose debug output")
+    graphic_parser.add_argument('--save-cache', type=argparse.FileType("w", encoding="utf-8"),
+                                help="Persist query results, which can be used with '--cache'")
     graphic_parser.add_argument('-o', '--output', action="store",
                                 default=os.getcwd(),
                                 help="Output directory for generated graphics")

--- a/onto_tool/onto_tool.py
+++ b/onto_tool/onto_tool.py
@@ -312,6 +312,10 @@ def generate_graphic(action, onto_files, endpoint, **kwargs):
     concentrate_links: int
         When the number links originating from the same class that share a single predicate exceed this threshold,
         use more compact display. Setting the value to 0 disables this behavior.
+    cache: TextIOWrapper
+        Read cached query results 
+    save_cache: TextIOWrapper
+        Save query results as JSON to use with --cache 
 
     Returns
     -------
@@ -320,6 +324,9 @@ def generate_graphic(action, onto_files, endpoint, **kwargs):
     """
     all_files = [file for ref in onto_files for file in expand_file_ref(ref)]
     og = OntoGraf(all_files, repo=endpoint, **kwargs)
+    if kwargs['cache'] and (endpoint or all_files):
+        logging.warning('Reading cached data from %s, ignoring endpoint/files',
+                        kwargs['cache'].name)
     if endpoint and all_files:
         logging.warning('Endpoint specified, ignoring files')
     if action == 'ontology':
@@ -1347,7 +1354,9 @@ def main(arguments):
                          include=args.include, exclude=args.exclude,
                          include_pattern=args.include_pattern,
                          exclude_pattern=args.exclude_pattern,
-                         show_shacl=args.show_shacl)
+                         show_shacl=args.show_shacl,
+                         cache=args.cache,
+                         save_cache=args.save_cache)
         return
 
     of = 'pretty-xml' if args.format == 'xml' else args.format

--- a/onto_tool/ontograph.py
+++ b/onto_tool/ontograph.py
@@ -139,7 +139,7 @@ class OntoGraf:
             self.cached_data[id] = data
             return data
         else:
-            return self.local_select_query(query)
+            return list(self.local_select_query(query))
 
     @staticmethod
     def strip_uri(uri):


### PR DESCRIPTION
Allow for caching instance data queries when generating a graphic, and then using the cached data in subsequent runs to faster tuning of render parameters.