### PR TITLE
updating class hierarchy SPARQL to stop following rdfs:subClassOf loops

### DIFF
--- a/onto_tool/ontograph.py
+++ b/onto_tool/ontograph.py
@@ -496,7 +496,8 @@ class OntoGraf:
              ?class (owl:equivalentClass|rdfs:subClassOf)/
                     (owl:unionOf|owl:intersectionOf)/
                     rdf:rest*/rdf:first ?parent .
-            ?parent a owl:Class
+            ?parent a owl:Class .
+            filter not exists { ?parent rdfs:subClassOf+ ?class }
           }
           filter (!isblank(?class) && !isblank(?parent))
           OPTIONAL {


### PR DESCRIPTION
adding filter not exists { ?parent rdfs:subClassOf+ ?class } to the SPARQL