### PR TITLE
Filter SHACL classes from diagrams

### DIFF
--- a/onto_tool/ontograph.py
+++ b/onto_tool/ontograph.py
@@ -727,6 +727,7 @@ class OntoGraf:
                               FILTER(!ISBLANK(?s))
                               ?s a ?src_c .
                               FILTER (!STRSTARTS(STR(?src_c), 'http://www.w3.org/2002/07/owl#'))
+                              FILTER (!STRSTARTS(STR(?src_c), 'http://www.w3.org/ns/shacl#'))
                               ?o a ?tgt_c .
                             } group by ?s ?o LIMIT $limit
                         }
@@ -744,6 +745,7 @@ class OntoGraf:
                               FILTER(!ISBLANK(?s) && ISLITERAL(?o))
                               ?s a ?src_c .
                               FILTER (!STRSTARTS(STR(?src_c), 'http://www.w3.org/2002/07/owl#'))
+                              FILTER (!STRSTARTS(STR(?src_c), 'http://www.w3.org/ns/shacl#'))
                               BIND(DATATYPE(?o) as ?dtype) .
                             } group by ?s LIMIT $limit
                         }

--- a/tests/graphic/instance_data.ttl
+++ b/tests/graphic/instance_data.ttl
@@ -2,6 +2,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix : <http://example.com/> .
 
 :Instances a owl:Ontology; owl:imports :Domain; rdfs:label "Instance Data" .
@@ -10,3 +11,4 @@
 :_u1 a :School; rdfs:isDefinedBy :Instances .
 :_s1 a :Student; :isFriendOf :_p1; rdfs:isDefinedBy :Instances .
 :_p1 a :Person; :hasPhoneNumber "123-456-7890"; rdfs:isDefinedBy :Instances .
+:_h1 a sh:NodeShape ; sh:targetClass :School ; rdfs:isDefinedBy :Instances .

--- a/tests/graphic/test_instance.py
+++ b/tests/graphic/test_instance.py
@@ -108,3 +108,20 @@ def test_concentration():
     ])
     (instance_graph,) = pydot.graph_from_dot_file('tests-output/graphic/concentration.dot')
     assert 4 == sum(1 for e in instance_graph.get_edges() if e.get_label() == 'playsWith')
+
+
+def test_shacl_instances():
+    onto_tool.main([
+        'graphic', '--predicate-threshold', '0', '--data',
+        '-t', 'Local Instance Data',
+        '--no-image',
+        '-o', 'tests-output/graphic/test_instance',
+        'tests/graphic/domain_ontology.ttl',
+        'tests/graphic/upper_ontology.ttl',
+        'tests/graphic/instance_data.ttl'
+    ])
+    (instance_graph,) = pydot.graph_from_dot_file('tests-output/graphic/test_instance.dot')
+    edges = list(sorted((e.get_source(), e.get_destination()) for e in instance_graph.get_edges()))
+    shacl_namespace = "http://www.w3.org/ns/shacl#"
+    shacl_edges = [edge for edge in edges if any(shacl_namespace in part for part in edge)]
+    assert 0 == len(shacl_edges)


### PR DESCRIPTION
Fixes #128.

@bpelakh -- This was the minimal change that successfully filtered out `NodeShape` from the diagrams. If you know of any other tweaks that should be made, please just let me know.