### PR TITLE
Add mode option to bundle definedBy action. Fixes #138

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,10 +362,16 @@ emitted as a `INFO`-level log message prior to the execution of the action.
 ##### RDF Transformation
 
 - `definedBy`, which inspects each input file to identify a single defined ontology, and then
-  adds a `rdfs:isDefinedBy` property to every `owl:Class`, `owl:ObjectProperty`, `owl:DatatypeProperty`
-  and `owl:AnnotationProperty` defined in the file referencing the identified ontology. Existing
-  `rdfs:isDefinedBy` values are removed prior to the addition. Input and output file specification
-  options are identical to those used by the `copy` action.
+  adds a `rdfs:isDefinedBy` property referencing the identified ontology to resources defined in the
+  file.
+  - `mode` - has two possible values, `strict` (the default) and `all`. If `mode` is `strict`, any resources
+    with type `owl:Class`, `owl:ObjectProperty`, `owl:DatatypeProperty` and `owl:AnnotationProperty` is
+    annotated. Otherwise, `mode` is `all` and any resource with a type and at least one other property is
+    annotated. Existing `rdfs:isDefinedBy` values are removed prior to the addition. Input and output file
+    specification options are identical to those used by the `copy` action.
+  - `versionedDefinedBy` - use `owl:versionIRI` for `rdfs:isDefinedBy`, when available.
+  - `retainDefinedBy` - by default, `definedBy` will override any existing `rdfs:definedBy` annotations,
+    but if this option is provided, existing annotations will be left in place.
 - `export`, which functions similarly to the command-line export functionality, gathering one or
   more input ontologies and exporting them as a single file, with some optional transformations,
   depending on the following specified options:

--- a/onto_tool/bundle.py
+++ b/onto_tool/bundle.py
@@ -243,7 +243,9 @@ def __bundle_defined_by__(action, variables):
             # copy as unchanged
             shutil.copy(in_out['inputFile'], in_out['outputFile'])
         else:
-            add_defined_by(g, ontology,
+            if not 'mode' in action:
+                action['mode'] = 'strict'
+            add_defined_by(g, ontology, mode=action['mode'],
                            replace=not __boolean_option__(
                                action, 'retainDefinedBy', variables),
                            versioned=__boolean_option__(action, 'versionedDefinedBy', variables))

--- a/onto_tool/bundle_schema.yaml
+++ b/onto_tool/bundle_schema.yaml
@@ -428,6 +428,11 @@ properties:
                     type: boolean
                   versionedDefinedBy:
                     type: boolean
+                  mode:
+                    type: string
+                    enum:
+                      - strict
+                      - all
         - if:
             properties:
               action:

--- a/tests/bundle/issue-138-output.ttl
+++ b/tests/bundle/issue-138-output.ttl
@@ -1,0 +1,16 @@
+@prefix : <https://data.clientX.com/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix star: <https://ontologies.pwc.com/starchart/> .
+
+:MyIndividual a star:Resource ;
+    skos:prefLabel "Tom" .
+
+<https://data.clientX.com/d/ontoName> a owl:Ontology ;
+    owl:versionIRI <https://data.clientX.com/d/ontoName1.0.0> .
+
+:myProperty a owl:DatatypeProperty ;
+    rdfs:isDefinedBy <https://data.clientX.com/d/ontoName1.0.0> ;
+    skos:prefLabel "my property" .
+

--- a/tests/bundle/issue-138.ttl
+++ b/tests/bundle/issue-138.ttl
@@ -1,0 +1,13 @@
+@prefix : <https://data.clientX.com/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix star: <https://ontologies.pwc.com/starchart/> .
+
+:MyIndividual a star:Resource ;
+    skos:prefLabel "Tom" .
+
+:myProperty a owl:DatatypeProperty ;
+    skos:prefLabel "my property" .
+
+<https://data.clientX.com/d/ontoName> a owl:Ontology ;
+    owl:versionIRI <https://data.clientX.com/d/ontoName1.0.0> .

--- a/tests/bundle/issue-138_all_mode.yaml
+++ b/tests/bundle/issue-138_all_mode.yaml
@@ -1,0 +1,9 @@
+bundle: test
+variables:
+  input: "tests/bundle"
+  output: "tests/bundle"
+actions:
+  - action: 'definedBy'
+    mode: 'all'
+    source: '{input}/issue-138.ttl'
+    target: '{output}/issue-138-output.ttl'

--- a/tests/bundle/issue-138_no_mode.yaml
+++ b/tests/bundle/issue-138_no_mode.yaml
@@ -1,0 +1,8 @@
+bundle: test
+variables:
+  input: "tests/bundle"
+  output: "tests/bundle"
+actions:
+  - action: 'definedBy'
+    source: '{input}/issue-138.ttl'
+    target: '{output}/issue-138-output.ttl'

--- a/tests/bundle/issue-138_strict_mode.yaml
+++ b/tests/bundle/issue-138_strict_mode.yaml
@@ -1,0 +1,9 @@
+bundle: test
+variables:
+  input: "tests/bundle"
+  output: "tests/bundle"
+actions:
+  - action: 'definedBy'
+    mode: 'strict'
+    source: '{input}/issue-138.ttl'
+    target: '{output}/issue-138-output.ttl'

--- a/tests/bundle/issue-138_versioned_iri.yaml
+++ b/tests/bundle/issue-138_versioned_iri.yaml
@@ -1,0 +1,9 @@
+bundle: test
+variables:
+  input: "tests/bundle"
+  output: "tests/bundle"
+actions:
+  - action: 'definedBy'
+    versionedDefinedBy: true
+    source: '{input}/issue-138.ttl'
+    target: '{output}/issue-138-output.ttl'

--- a/tests/bundle/test_issue-138.py
+++ b/tests/bundle/test_issue-138.py
@@ -1,0 +1,68 @@
+from rdflib import Graph, URIRef
+from rdflib.namespace import RDFS
+from onto_tool import onto_tool
+
+import pytest
+import os
+
+def lists_equal(list_one, list_two):
+    return len(list_one) == len(list_two) and sorted(list_one) == sorted(list_two)
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    yield
+    # os.remove('tests/bundle/issue-138-output.ttl')
+
+
+def test_bundle_no_defined_by():
+    onto_tool.main([
+        'bundle',
+        'tests/bundle/issue-138_no_mode.yaml'])
+    graph = Graph()
+    graph.parse('tests/bundle/issue-138-output.ttl', format="turtle")
+    assert len(graph) == 7
+    assert lists_equal(
+        list(graph.subject_objects(RDFS.isDefinedBy)),
+        [(URIRef('https://data.clientX.com/myProperty'), URIRef('https://data.clientX.com/d/ontoName'))]
+    )
+
+
+def test_bundle_strict_defined_by():
+    onto_tool.main([
+        'bundle',
+        'tests/bundle/issue-138_strict_mode.yaml'])
+    graph = Graph()
+    graph.parse('tests/bundle/issue-138-output.ttl', format="turtle")
+    assert len(graph) == 7
+    assert lists_equal(
+        list(graph.subject_objects(RDFS.isDefinedBy)),
+        [(URIRef('https://data.clientX.com/myProperty'), URIRef('https://data.clientX.com/d/ontoName'))]
+    )
+
+
+def test_bundle_all_defined_by():
+    onto_tool.main([
+        'bundle',
+        'tests/bundle/issue-138_all_mode.yaml'])
+    graph = Graph()
+    graph.parse('tests/bundle/issue-138-output.ttl', format="turtle")
+    assert len(graph) == 8
+    assert lists_equal(
+        list(graph.subject_objects(RDFS.isDefinedBy)),
+        [(URIRef('https://data.clientX.com/MyIndividual'), URIRef('https://data.clientX.com/d/ontoName')),
+         (URIRef('https://data.clientX.com/myProperty'), URIRef('https://data.clientX.com/d/ontoName'))]
+    )
+
+
+def test_bundle_versioned_defined_by():
+    onto_tool.main([
+        'bundle',
+        'tests/bundle/issue-138_versioned_iri.yaml'])
+    graph = Graph()
+    graph.parse('tests/bundle/issue-138-output.ttl', format="turtle")
+    assert len(graph) == 7
+    assert lists_equal(
+        list(graph.subject_objects(RDFS.isDefinedBy)),
+        [(URIRef('https://data.clientX.com/myProperty'), URIRef('https://data.clientX.com/d/ontoName1.0.0'))]
+    )


### PR DESCRIPTION
Add `mode` options to the bundle yaml schema and check the `mode` value in `__bundle_defined_by__()`

Add tests with new test bundle definitions. The `tmp_path` approach used in other tests isn't as clean here because the output file path needs to be specified in the bundle definition. If we prefer `tmp_path`, we could write the bundle definition to `tmp_path` at the start of each test.